### PR TITLE
Integrate parser and tokenizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/02/11 15:47:17 by amakinen          #+#    #+#              #
-#    Updated: 2025/03/31 20:58:31 by amakinen         ###   ########.fr        #
+#    Updated: 2025/04/02 18:18:26 by amakinen         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -41,6 +41,7 @@ $(NAME): tgt_LDLIBS := -lreadline
 TESTDIR := test
 TESTS := $(addprefix $(TESTDIR)/,\
 	tokenizer \
+	input_parser \
 )
 TEST_SRCS := $(TESTS:%=$(SRCDIR)/%.c)
 # - Remove main.o from OBJS as each test comes with its own main

--- a/include/parser.h
+++ b/include/parser.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 12:50:10 by josmanov          #+#    #+#             */
-/*   Updated: 2025/04/02 17:49:21 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/02 17:55:36 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,10 +23,6 @@ enum	e_parser_status
 	PARSER_ERR_MALLOC,
 };
 
-struct	s_parser_state;
-
-enum e_parser_status	parser_parse(
-							struct s_parser_state *state,
-							struct s_ast_list_entry **root);
+enum e_parser_status	parser_parse(struct s_ast_list_entry **root);
 
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 12:50:10 by josmanov          #+#    #+#             */
-/*   Updated: 2025/03/31 19:42:59 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/02 17:49:21 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,8 +23,10 @@ enum	e_parser_status
 	PARSER_ERR_MALLOC,
 };
 
+struct	s_parser_state;
+
 enum e_parser_status	parser_parse(
-							struct s_token **tokens,
+							struct s_parser_state *state,
 							struct s_ast_list_entry **root);
 
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 12:50:10 by josmanov          #+#    #+#             */
-/*   Updated: 2025/04/02 17:55:36 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/02 17:58:17 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,7 @@
 enum	e_parser_status
 {
 	PARSER_SUCCESS,
+	PARSER_EOF,
 	PARSER_ERR_SYNTAX,
 	PARSER_ERR_MALLOC,
 };

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 01:58:09 by josmanov          #+#    #+#             */
-/*   Updated: 2025/03/31 20:47:56 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/02 17:42:56 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,19 +20,19 @@
 	Top-level parsing function. Parses a complete command line.
 	Stores the created AST in the pointer pointed to by `root`.
 */
-enum e_parser_status	parser_parse(struct s_token **tokens,
+enum e_parser_status	parser_parse(struct s_parser_state *state,
 	struct s_ast_list_entry **root)
 {
 	enum e_parser_status	status;
 
-	status = parser_list(tokens, root);
+	status = parser_list(state, root);
 	if (status != PARSER_SUCCESS)
 		return (status);
-	if ((*tokens)->type != TOK_END)
+	if (state->curr_tok.type != TOK_END)
 	{
 		parser_syntax_error("unexpected token");
 		return (PARSER_ERR_SYNTAX);
 	}
-	(*tokens)++;
+	parser_next_token(state);
 	return (PARSER_SUCCESS);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -16,6 +16,11 @@
 #include "ast.h"
 #include "tokenizer.h"
 
+void	parser_next_token(struct s_parser_state *state)
+{
+	state->curr_tok = tokenizer_get_next(&state->tok_state);
+}
+
 /*
 	Top-level parsing function. Parses a complete command line.
 	Stores the created AST in the pointer pointed to by `root`.

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,12 +6,14 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 01:58:09 by josmanov          #+#    #+#             */
-/*   Updated: 2025/04/02 17:42:56 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/02 17:56:55 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
 #include "parser_internal.h"
+
+#include <stddef.h>
 
 #include "ast.h"
 #include "tokenizer.h"
@@ -25,19 +27,26 @@ void	parser_next_token(struct s_parser_state *state)
 	Top-level parsing function. Parses a complete command line.
 	Stores the created AST in the pointer pointed to by `root`.
 */
-enum e_parser_status	parser_parse(struct s_parser_state *state,
-	struct s_ast_list_entry **root)
+enum e_parser_status	parser_parse(struct s_ast_list_entry **root)
 {
 	enum e_parser_status	status;
+	struct s_parser_state	state;
 
-	status = parser_list(state, root);
+	state.tok_state.line = NULL;
+	state.tok_state.eof_reached = false;
+	parser_next_token(&state);
+	if (state.curr_tok.type == TOK_END)
+	{
+		*root = NULL;
+		return (PARSER_SUCCESS);
+	}
+	status = parser_list(&state, root);
 	if (status != PARSER_SUCCESS)
 		return (status);
-	if (state->curr_tok.type != TOK_END)
+	if (state.curr_tok.type != TOK_END)
 	{
 		parser_syntax_error("unexpected token");
 		return (PARSER_ERR_SYNTAX);
 	}
-	parser_next_token(state);
 	return (PARSER_SUCCESS);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 01:58:09 by josmanov          #+#    #+#             */
-/*   Updated: 2025/04/03 19:21:51 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/03 19:27:49 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,7 +37,9 @@ enum e_parser_status	parser_parse(struct s_ast_list_entry **root)
 	parser_next_token(&state);
 	*root = NULL;
 	status = PARSER_SUCCESS;
-	if (state.curr_tok.type != TOK_END)
+	if (state.tok_state.eof_reached)
+		status = PARSER_EOF;
+	else if (state.curr_tok.type != TOK_END)
 		status = parser_list(&state, root);
 	if (status == PARSER_SUCCESS && state.curr_tok.type != TOK_END)
 	{

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,14 +6,14 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 01:58:09 by josmanov          #+#    #+#             */
-/*   Updated: 2025/04/02 17:56:55 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/03 19:21:51 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
 #include "parser_internal.h"
 
-#include <stddef.h>
+#include <stdlib.h>
 
 #include "ast.h"
 #include "tokenizer.h"
@@ -35,18 +35,15 @@ enum e_parser_status	parser_parse(struct s_ast_list_entry **root)
 	state.tok_state.line = NULL;
 	state.tok_state.eof_reached = false;
 	parser_next_token(&state);
-	if (state.curr_tok.type == TOK_END)
-	{
-		*root = NULL;
-		return (PARSER_SUCCESS);
-	}
-	status = parser_list(&state, root);
-	if (status != PARSER_SUCCESS)
-		return (status);
+	*root = NULL;
+	status = PARSER_SUCCESS;
 	if (state.curr_tok.type != TOK_END)
+		status = parser_list(&state, root);
+	if (status == PARSER_SUCCESS && state.curr_tok.type != TOK_END)
 	{
 		parser_syntax_error("unexpected token");
-		return (PARSER_ERR_SYNTAX);
+		status = PARSER_ERR_SYNTAX;
 	}
-	return (PARSER_SUCCESS);
+	free(state.tok_state.line);
+	return (status);
 }

--- a/src/parser/parser_group.c
+++ b/src/parser/parser_group.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 01:58:24 by josmanov          #+#    #+#             */
-/*   Updated: 2025/03/31 20:47:46 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/02 16:08:48 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,20 +21,20 @@
 	Next token must be TOK_GROUP_START.
 */
 enum e_parser_status	parser_group(
-	struct s_token **tokens,
+	struct s_parser_state *state,
 	struct s_ast_list_entry **group_head)
 {
 	enum e_parser_status		status;
 
-	(*tokens)++;
-	status = parser_list(tokens, group_head);
+	parser_next_token(state);
+	status = parser_list(state, group_head);
 	if (status != PARSER_SUCCESS)
 		return (status);
-	if ((*tokens)->type != TOK_GROUP_END)
+	if (state->curr_tok.type != TOK_GROUP_END)
 	{
 		parser_syntax_error("expected closing parenthesis");
 		return (PARSER_ERR_SYNTAX);
 	}
-	(*tokens)++;
+	parser_next_token(state);
 	return (PARSER_SUCCESS);
 }

--- a/src/parser/parser_internal.h
+++ b/src/parser/parser_internal.h
@@ -17,6 +17,12 @@
 # include "ast.h"
 # include "tokenizer.h"
 
+struct	s_parser_state
+{
+	struct s_token				curr_tok;
+	struct s_tokenizer_state	tok_state;
+};
+
 void					parser_next_token(struct s_parser_state *state);
 
 /* Command parsing functions */

--- a/src/parser/parser_internal.h
+++ b/src/parser/parser_internal.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 16:49:57 by amakinen          #+#    #+#             */
-/*   Updated: 2025/03/31 20:47:48 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/02 16:02:55 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,25 +17,27 @@
 # include "ast.h"
 # include "tokenizer.h"
 
+void					parser_next_token(struct s_parser_state *state);
+
 /* Command parsing functions */
 
 enum e_parser_status	parser_word(
-							struct s_token **tokens,
+							struct s_parser_state *state,
 							struct s_ast_command_word **word);
 enum e_parser_status	parser_redirect(
-							struct s_token **tokens,
+							struct s_parser_state *state,
 							struct s_ast_redirect **redirect);
 enum e_parser_status	parser_simple_command(
-							struct s_token **tokens,
+							struct s_parser_state *state,
 							struct s_ast_simple_command **simple_command);
 enum e_parser_status	parser_pipeline(
-							struct s_token **tokens,
+							struct s_parser_state *state,
 							struct s_ast_simple_command **pipeline_head);
 enum e_parser_status	parser_list(
-							struct s_token **tokens,
+							struct s_parser_state *state,
 							struct s_ast_list_entry **list_head);
 enum e_parser_status	parser_group(
-							struct s_token **tokens,
+							struct s_parser_state *state,
 							struct s_ast_list_entry **group_head);
 
 /* Error handling helper */

--- a/src/parser/parser_list.c
+++ b/src/parser/parser_list.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/01 14:22:36 by josmanov          #+#    #+#             */
-/*   Updated: 2025/03/31 20:47:49 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/02 16:08:48 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@
 	A list entry can be either a pipeline or a group.
 */
 static enum e_parser_status	parser_list_entry(
-	struct s_token **tokens,
+	struct s_parser_state *state,
 	struct s_ast_list_entry **list_append)
 {
 	enum e_parser_status		status;
@@ -34,17 +34,17 @@ static enum e_parser_status	parser_list_entry(
 		return (PARSER_ERR_MALLOC);
 	*list_append = new_entry;
 	new_entry->next = NULL;
-	if ((*tokens)->type == TOK_GROUP_START)
+	if (state->curr_tok.type == TOK_GROUP_START)
 	{
 		new_entry->type = AST_LIST_GROUP;
 		new_entry->group = NULL;
-		status = parser_group(tokens, &(new_entry->group));
+		status = parser_group(state, &(new_entry->group));
 	}
 	else
 	{
 		new_entry->type = AST_LIST_PIPELINE;
 		new_entry->pipeline = NULL;
-		status = parser_pipeline(tokens, &(new_entry->pipeline));
+		status = parser_pipeline(state, &(new_entry->pipeline));
 	}
 	return (status);
 }
@@ -53,7 +53,7 @@ static enum e_parser_status	parser_list_entry(
 	Parses a list of commands separated by && or || operators.
 */
 enum e_parser_status	parser_list(
-	struct s_token **tokens,
+	struct s_parser_state *state,
 	struct s_ast_list_entry **list_head)
 {
 	enum e_parser_status	status;
@@ -62,16 +62,16 @@ enum e_parser_status	parser_list(
 	list_append = list_head;
 	while (1)
 	{
-		status = parser_list_entry(tokens, list_append);
+		status = parser_list_entry(state, list_append);
 		if (status != PARSER_SUCCESS)
 			return (status);
-		if ((*tokens)->type == TOK_AND)
+		if (state->curr_tok.type == TOK_AND)
 			(*list_append)->next_op = AST_LIST_AND;
-		else if ((*tokens)->type == TOK_OR)
+		else if (state->curr_tok.type == TOK_OR)
 			(*list_append)->next_op = AST_LIST_OR;
 		else
 			break ;
-		(*tokens)++;
+		parser_next_token(state);
 		list_append = &((*list_append)->next);
 	}
 	return (PARSER_SUCCESS);

--- a/src/parser/parser_pipeline.c
+++ b/src/parser/parser_pipeline.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/15 14:22:31 by josmanov          #+#    #+#             */
-/*   Updated: 2025/03/31 20:47:51 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/02 16:08:48 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,10 +18,10 @@
 
 /*
 	Parses a pipeline from the token list.
-	Pipelines consist of simple commands separated by pipe tokens.
+	Pipelines consist of simple commands separated by pipe state.
 */
 enum e_parser_status	parser_pipeline(
-	struct s_token **tokens,
+	struct s_parser_state *state,
 	struct s_ast_simple_command **pipeline_head)
 {
 	enum e_parser_status		status;
@@ -30,12 +30,12 @@ enum e_parser_status	parser_pipeline(
 	pipeline_append = pipeline_head;
 	while (1)
 	{
-		status = parser_simple_command(tokens, pipeline_append);
+		status = parser_simple_command(state, pipeline_append);
 		if (status != PARSER_SUCCESS)
 			return (status);
-		if ((*tokens)->type != TOK_PIPE)
+		if (state->curr_tok.type != TOK_PIPE)
 			break ;
-		(*tokens)++;
+		parser_next_token(state);
 		pipeline_append = &((*pipeline_append)->next);
 	}
 	return (PARSER_SUCCESS);

--- a/src/parser/parser_redirect.c
+++ b/src/parser/parser_redirect.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/01 11:22:25 by josmanov          #+#    #+#             */
-/*   Updated: 2025/03/31 20:48:24 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/02 16:05:41 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,7 @@ static enum e_ast_redirect_op	redirect_token_to_op(enum e_token type)
 	Next token must be a redirect token.
 */
 enum e_parser_status	parser_redirect(
-	struct s_token **tokens,
+	struct s_parser_state *state,
 	struct s_ast_redirect **redirect)
 {
 	struct s_ast_redirect	*new_redir;
@@ -46,14 +46,14 @@ enum e_parser_status	parser_redirect(
 	*redirect = new_redir;
 	new_redir->next = NULL;
 	new_redir->word = NULL;
-	new_redir->op = redirect_token_to_op((*tokens)->type);
-	(*tokens)++;
-	if ((*tokens)->type != TOK_WORD)
+	new_redir->op = redirect_token_to_op(state->curr_tok.type);
+	parser_next_token(state);
+	if (state->curr_tok.type != TOK_WORD)
 	{
 		parser_syntax_error("expected word for redirect");
 		return (PARSER_ERR_SYNTAX);
 	}
-	new_redir->word = (*tokens)->word_content;
-	(*tokens)++;
+	new_redir->word = state->curr_tok.word_content;
+	parser_next_token(state);
 	return (PARSER_SUCCESS);
 }

--- a/src/parser/parser_simple_command.c
+++ b/src/parser/parser_simple_command.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 01:53:36 by josmanov          #+#    #+#             */
-/*   Updated: 2025/03/31 20:47:53 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/02 16:08:49 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,15 +19,15 @@
 #include "parser.h"
 #include "tokenizer.h"
 
-static bool	is_redirect_token(struct s_token *token)
+static bool	is_redirect_token(struct s_parser_state *state)
 {
-	if (token->type == TOK_REDIR_IN)
+	if (state->curr_tok.type == TOK_REDIR_IN)
 		return (true);
-	if (token->type == TOK_REDIR_OUT)
+	if (state->curr_tok.type == TOK_REDIR_OUT)
 		return (true);
-	if (token->type == TOK_REDIR_APP)
+	if (state->curr_tok.type == TOK_REDIR_APP)
 		return (true);
-	if (token->type == TOK_HEREDOC)
+	if (state->curr_tok.type == TOK_HEREDOC)
 		return (true);
 	return (false);
 }
@@ -36,7 +36,7 @@ static bool	is_redirect_token(struct s_token *token)
 	Process elements of a command (words and redirections).
 */
 static enum e_parser_status	process_command_elements(
-	struct s_token **tokens,
+	struct s_parser_state *state,
 	struct s_ast_simple_command *new_command)
 {
 	enum e_parser_status		status;
@@ -45,18 +45,18 @@ static enum e_parser_status	process_command_elements(
 
 	args_append = &new_command->args;
 	redirs_append = &new_command->redirs;
-	while (is_redirect_token(*tokens) || (*tokens)->type == TOK_WORD)
+	while (is_redirect_token(state) || state->curr_tok.type == TOK_WORD)
 	{
-		if (is_redirect_token(*tokens))
+		if (is_redirect_token(state))
 		{
-			status = parser_redirect(tokens, redirs_append);
+			status = parser_redirect(state, redirs_append);
 			if (status != PARSER_SUCCESS)
 				return (status);
 			redirs_append = &(*redirs_append)->next;
 		}
 		else
 		{
-			status = parser_word(tokens, args_append);
+			status = parser_word(state, args_append);
 			if (status != PARSER_SUCCESS)
 				return (status);
 			args_append = &(*args_append)->next;
@@ -69,7 +69,7 @@ static enum e_parser_status	process_command_elements(
 	Parses a simple command from the token list.
 */
 enum e_parser_status	parser_simple_command(
-	struct s_token **tokens,
+	struct s_parser_state *state,
 	struct s_ast_simple_command **simple_command)
 {
 	enum e_parser_status		status;
@@ -82,7 +82,7 @@ enum e_parser_status	parser_simple_command(
 	new_command->next = NULL;
 	new_command->args = NULL;
 	new_command->redirs = NULL;
-	status = process_command_elements(tokens, new_command);
+	status = process_command_elements(state, new_command);
 	if (status != PARSER_SUCCESS)
 		return (status);
 	if (new_command->args == NULL && new_command->redirs == NULL)

--- a/src/parser/parser_word.c
+++ b/src/parser/parser_word.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/01 11:22:25 by josmanov          #+#    #+#             */
-/*   Updated: 2025/03/31 20:48:43 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/02 16:05:41 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@
 	Next token must be TOK_WORD.
 */
 enum e_parser_status	parser_word(
-	struct s_token **tokens,
+	struct s_parser_state *state,
 	struct s_ast_command_word **word)
 {
 	struct s_ast_command_word	*new_word;
@@ -32,7 +32,7 @@ enum e_parser_status	parser_word(
 		return (PARSER_ERR_MALLOC);
 	*word = new_word;
 	new_word->next = NULL;
-	new_word->word = (*tokens)->word_content;
-	(*tokens)++;
+	new_word->word = state->curr_tok.word_content;
+	parser_next_token(state);
 	return (PARSER_SUCCESS);
 }

--- a/src/test/input_parser.c
+++ b/src/test/input_parser.c
@@ -1,0 +1,127 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   input_parser.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/02 16:17:11 by amakinen          #+#    #+#             */
+/*   Updated: 2025/04/02 17:21:50 by amakinen         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <stdio.h>
+
+#include "ast.h"
+#include "parser.h"
+
+#define INDENT_STEP 4
+
+static char	*redir_op_sym(enum e_ast_redirect_op redir_op)
+{
+	if (redir_op == AST_REDIR_IN)
+		return ("<");
+	else if (redir_op == AST_REDIR_OUT)
+		return (">");
+	else if (redir_op == AST_REDIR_APP)
+		return (">>");
+	else if (redir_op == AST_HEREDOC)
+		return ("<<");
+	else
+		return (NULL);
+}
+
+static void	print_command(struct s_ast_simple_command *command, int indent)
+{
+	struct s_ast_command_word	*arg;
+	struct s_ast_redirect		*redir;
+	char						*redir_sym;
+
+	printf("%*sSimple command:\n", indent, "");
+	indent += INDENT_STEP;
+	arg = command->args;
+	while (arg)
+	{
+		printf("%*sArg: [%s]\n", indent, "", arg->word);
+		arg = arg->next;
+	}
+	redir = command->redirs;
+	while (redir)
+	{
+		redir_sym = redir_op_sym(redir->op);
+		if (redir_sym)
+			printf("%*sRedirect: %s [%s]\n",
+				indent, "", redir_sym, redir->word);
+		else
+			printf("%*sRedirect: \e[91mBad redir op %d [%s]\n",
+				indent, "", redir->op, redir->word);
+		redir = redir->next;
+	}
+}
+
+static void	print_pipeline(struct s_ast_simple_command *pipeline, int indent)
+{
+	printf("%*sPipeline:\n", indent, "");
+	indent += INDENT_STEP;
+	while (1)
+	{
+		print_command(pipeline, indent);
+		if (!pipeline->next)
+			break ;
+		pipeline = pipeline->next;
+	}
+}
+
+static void	print_list(struct s_ast_list_entry *list, int indent)
+{
+	printf("%*sList:\n", indent, "");
+	indent += INDENT_STEP;
+	while (1)
+	{
+		if (list->type == AST_LIST_GROUP)
+			print_list(list->group, indent);
+		else if (list->type == AST_LIST_PIPELINE)
+			print_pipeline(list->pipeline, indent);
+		else
+			printf("%*s\e[91mBad list entry type %d\e[m\n",
+				indent, "", list->type);
+		if (!list->next)
+			break ;
+		if (list->next_op == AST_LIST_AND)
+			printf("%*s&&\n", indent, "");
+		else if (list->next_op == AST_LIST_OR)
+			printf("%*s||\n", indent, "");
+		else
+			printf("%*s\e[91mBad list op %d\e[m\n", indent, "", list->next_op);
+		list = list->next;
+	}
+}
+
+int	main(void)
+{
+	enum e_parser_status	ps;
+	struct s_ast_list_entry	*root;
+
+	while (1)
+	{
+		ps = parser_parse(&root);
+		if (ps == PARSER_EOF || ps == PARSER_ERR_MALLOC)
+			break ;
+		if (ps == PARSER_ERR_SYNTAX)
+			printf("try again\n");
+		else if (!root)
+			printf("empty command\n");
+		else
+		{
+			print_list(root, 0);
+			free_ast(root);
+		}
+	}
+	if (ps == PARSER_EOF)
+		printf("done\n");
+	else
+	{
+		printf("malloc error\n");
+		return (1);
+	}
+}

--- a/src/test/tokenizer.c
+++ b/src/test/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 16:42:39 by amakinen          #+#    #+#             */
-/*   Updated: 2025/02/26 16:56:15 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/03 19:23:59 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,9 +50,15 @@ int	main(void)
 	{
 		debug_print_token(token);
 		free(token.word_content);
+		if (token.type == TOK_END)
+		{
+			free(ts.line);
+			ts.line = NULL;
+		}
 		token = tokenizer_get_next(&ts);
 	}
 	debug_print_token(token);
 	free(token.word_content);
+	free(ts.line);
 	return (0);
 }

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 16:53:50 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/03 19:04:14 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/03 19:12:16 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -119,14 +119,16 @@ t_token	tokenizer_get_next(t_tokenizer_state *state)
 		state->line = readline("test prompt");
 		state->line_pos = state->line;
 	}
-	if (!state->line || *state->line_pos == '\0')
+	if (!state->line)
 	{
-		state->eof_reached = state->line == NULL;
+		state->eof_reached = true;
 		return ((t_token){TOK_END, NULL});
 	}
 	while (tok_isblank(*state->line_pos))
 		state->line_pos++;
-	if (tok_is_operator(state, &op_type))
+	if (*state->line_pos == '\0')
+		return ((t_token){TOK_END, NULL});
+	else if (tok_is_operator(state, &op_type))
 		return ((t_token){op_type, NULL});
 	else
 		return ((t_token){TOK_WORD, tok_build_word(state)});

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 16:53:50 by amakinen          #+#    #+#             */
-/*   Updated: 2025/02/20 20:42:12 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/03 19:04:14 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -122,8 +122,6 @@ t_token	tokenizer_get_next(t_tokenizer_state *state)
 	if (!state->line || *state->line_pos == '\0')
 	{
 		state->eof_reached = state->line == NULL;
-		free(state->line);
-		state->line = NULL;
 		return ((t_token){TOK_END, NULL});
 	}
 	while (tok_isblank(*state->line_pos))


### PR DESCRIPTION
Parser now directly parses lines returned by readline.

Run `test/input_parser` and type minishell input, and you'll see either AST or an error message.

Valid syntax example: `abc | def > ghi <<jkl && mno || ("pqrs  'tu"'"vw"'   xyz && ( ((abc)) || def | ghi) )`.