### PR TITLE
Implement minishell main loop

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 12:50:10 by josmanov          #+#    #+#             */
-/*   Updated: 2025/04/02 17:58:17 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/07 16:56:10 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,16 +14,15 @@
 # define PARSER_H
 
 # include "ast.h"
-# include "tokenizer.h"
 
 enum	e_parser_status
 {
 	PARSER_SUCCESS,
-	PARSER_EOF,
 	PARSER_ERR_SYNTAX,
 	PARSER_ERR_MALLOC,
 };
 
-enum e_parser_status	parser_parse(struct s_ast_list_entry **root);
+enum e_parser_status	parser_parse(char *line,
+							struct s_ast_list_entry **root);
 
 #endif

--- a/include/tokenizer.h
+++ b/include/tokenizer.h
@@ -6,14 +6,12 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 16:50:25 by amakinen          #+#    #+#             */
-/*   Updated: 2025/02/20 20:38:22 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/07 16:15:59 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef TOKENIZER_H
 # define TOKENIZER_H
-
-# include <stdbool.h>
 
 enum	e_token
 {
@@ -38,9 +36,7 @@ typedef struct s_token
 
 typedef struct s_tokenizer_state
 {
-	char	*line;
 	char	*line_pos;
-	bool	eof_reached;
 }	t_tokenizer_state;
 
 typedef struct s_operator_def

--- a/src/main.c
+++ b/src/main.c
@@ -6,18 +6,40 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/11 15:55:33 by amakinen          #+#    #+#             */
-/*   Updated: 2025/02/11 17:10:15 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/07 17:24:06 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "libft.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <readline/readline.h>
 
-int	main(int argc, char **argv)
+#include "ast.h"
+#include "parser.h"
+#include "execute.h"
+
+/*
+	TODO: exit status for errors
+	TODO: message and cleanup for malloc and other fatal errors
+*/
+
+int	main(void)
 {
-	int	i;
+	char					*line;
+	struct s_ast_list_entry	*ast;
+	enum e_parser_status	status;
 
-	i = 0;
-	while (i < argc)
-		ft_putendl_fd(argv[i++], 1);
-	return (0);
+	while (1)
+	{
+		line = readline("minishell> ");
+		if (!line)
+			break ;
+		status = parser_parse(line, &ast);
+		free(line);
+		if (status == PARSER_SUCCESS)
+			execute_list(ast);
+		free_ast(ast);
+		if (status == PARSER_ERR_MALLOC)
+			return (1);
+	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,12 +6,13 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/11 15:55:33 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/07 17:24:06 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/07 17:28:36 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <readline/history.h>
 #include <readline/readline.h>
 
 #include "ast.h"
@@ -35,6 +36,8 @@ int	main(void)
 		if (!line)
 			break ;
 		status = parser_parse(line, &ast);
+		if (status == PARSER_SUCCESS && ast)
+			add_history(line);
 		free(line);
 		if (status == PARSER_SUCCESS)
 			execute_list(ast);

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 01:58:09 by josmanov          #+#    #+#             */
-/*   Updated: 2025/04/03 19:27:49 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/07 16:34:11 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,8 @@
 #include "parser_internal.h"
 
 #include <stdlib.h>
+#include <stdio.h>
+#include <readline/readline.h>
 
 #include "ast.h"
 #include "tokenizer.h"
@@ -31,21 +33,22 @@ enum e_parser_status	parser_parse(struct s_ast_list_entry **root)
 {
 	enum e_parser_status	status;
 	struct s_parser_state	state;
+	char					*line;
 
-	state.tok_state.line = NULL;
-	state.tok_state.eof_reached = false;
+	line = readline("minishell> ");
+	if (!line)
+		return (PARSER_EOF);
+	state.tok_state.line_pos = line;
 	parser_next_token(&state);
 	*root = NULL;
 	status = PARSER_SUCCESS;
-	if (state.tok_state.eof_reached)
-		status = PARSER_EOF;
-	else if (state.curr_tok.type != TOK_END)
+	if (state.curr_tok.type != TOK_END)
 		status = parser_list(&state, root);
 	if (status == PARSER_SUCCESS && state.curr_tok.type != TOK_END)
 	{
 		parser_syntax_error("unexpected token");
 		status = PARSER_ERR_SYNTAX;
 	}
-	free(state.tok_state.line);
+	free(line);
 	return (status);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,16 +6,14 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 01:58:09 by josmanov          #+#    #+#             */
-/*   Updated: 2025/04/07 16:34:11 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/07 16:57:24 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
 #include "parser_internal.h"
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <readline/readline.h>
+#include <stddef.h>
 
 #include "ast.h"
 #include "tokenizer.h"
@@ -29,15 +27,11 @@ void	parser_next_token(struct s_parser_state *state)
 	Top-level parsing function. Parses a complete command line.
 	Stores the created AST in the pointer pointed to by `root`.
 */
-enum e_parser_status	parser_parse(struct s_ast_list_entry **root)
+enum e_parser_status	parser_parse(char *line, struct s_ast_list_entry **root)
 {
 	enum e_parser_status	status;
 	struct s_parser_state	state;
-	char					*line;
 
-	line = readline("minishell> ");
-	if (!line)
-		return (PARSER_EOF);
 	state.tok_state.line_pos = line;
 	parser_next_token(&state);
 	*root = NULL;
@@ -49,6 +43,5 @@ enum e_parser_status	parser_parse(struct s_ast_list_entry **root)
 		parser_syntax_error("unexpected token");
 		status = PARSER_ERR_SYNTAX;
 	}
-	free(line);
 	return (status);
 }

--- a/src/test/input_parser.c
+++ b/src/test/input_parser.c
@@ -6,11 +6,13 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/02 16:17:11 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/02 17:21:50 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/07 17:02:32 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <readline/readline.h>
 
 #include "ast.h"
 #include "parser.h"
@@ -101,27 +103,27 @@ int	main(void)
 {
 	enum e_parser_status	ps;
 	struct s_ast_list_entry	*root;
+	char					*line;
 
 	while (1)
 	{
-		ps = parser_parse(&root);
-		if (ps == PARSER_EOF || ps == PARSER_ERR_MALLOC)
+		line = readline("input parser> ");
+		if (!line)
 			break ;
+		ps = parser_parse(line, &root);
+		if (ps == PARSER_ERR_MALLOC)
+		{
+			printf("malloc error\n");
+			return (1);
+		}
 		if (ps == PARSER_ERR_SYNTAX)
 			printf("try again\n");
 		else if (!root)
 			printf("empty command\n");
 		else
-		{
 			print_list(root, 0);
-			free_ast(root);
-		}
+		free_ast(root);
+		free(line);
 	}
-	if (ps == PARSER_EOF)
-		printf("done\n");
-	else
-	{
-		printf("malloc error\n");
-		return (1);
-	}
+	printf("done\n");
 }

--- a/src/test/tokenizer.c
+++ b/src/test/tokenizer.c
@@ -6,14 +6,14 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 16:42:39 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/03 19:23:59 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/07 16:26:16 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <readline/readline.h>
 
-#include "libft.h"
 #include "tokenizer.h"
 
 static const char		*g_tok_names[] = {
@@ -42,23 +42,23 @@ int	main(void)
 {
 	t_token				token;
 	t_tokenizer_state	ts;
+	char				*line;
 
-	ts.line = NULL;
-	ts.eof_reached = false;
-	token = tokenizer_get_next(&ts);
-	while (!ts.eof_reached)
+	line = NULL;
+	token.type = TOK_END;
+	while (1)
 	{
-		debug_print_token(token);
-		free(token.word_content);
 		if (token.type == TOK_END)
 		{
-			free(ts.line);
-			ts.line = NULL;
+			free(line);
+			line = readline("tokenizer> ");
+			if (!line)
+				break ;
+			ts.line_pos = line;
 		}
 		token = tokenizer_get_next(&ts);
+		debug_print_token(token);
+		free(token.word_content);
 	}
-	debug_print_token(token);
-	free(token.word_content);
-	free(ts.line);
 	return (0);
 }

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -6,16 +6,14 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 16:53:50 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/03 19:12:16 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/07 17:01:02 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "tokenizer.h"
 
 #include <stdbool.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <readline/readline.h>
 
 #include "libft.h"
 
@@ -114,16 +112,6 @@ t_token	tokenizer_get_next(t_tokenizer_state *state)
 {
 	enum e_token	op_type;
 
-	if (!state->line)
-	{
-		state->line = readline("test prompt");
-		state->line_pos = state->line;
-	}
-	if (!state->line)
-	{
-		state->eof_reached = true;
-		return ((t_token){TOK_END, NULL});
-	}
 	while (tok_isblank(*state->line_pos))
 		state->line_pos++;
 	if (*state->line_pos == '\0')


### PR DESCRIPTION
We can now parse input and execute external programs!

We're not waiting for child processes yet though, so next prompt appears before command output, and commands that read stdin (without redirection) compete with the shell process for input.

Exit status is faked in execute_pipeline which affects list operators.

There is also no path search yet, so full path to command is required, e.g. `/bin/echo`.