### PR TITLE
Implement pattern matching for pathname expansion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/02/11 15:47:17 by amakinen          #+#    #+#              #
-#    Updated: 2025/04/16 15:51:22 by amakinen         ###   ########.fr        #
+#    Updated: 2025/04/19 19:29:08 by amakinen         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -38,6 +38,7 @@ SRCS := $(addprefix $(SRCDIR)/,\
 	word/word_exp.c \
 	word/word_filename.c \
 	word/word_heredoc.c \
+	word/word_pattern.c \
 	word/word_scan.c \
 	word/word_unescape.c \
 )

--- a/src/word/word_filename.c
+++ b/src/word/word_filename.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/11 15:48:35 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/11 19:06:46 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/19 19:36:26 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,8 +19,8 @@
 
 #include "libft.h"
 
-static bool	word_filename_matches(char *value, char *pattern);
-static void	word_filename_append(char *value, struct s_word_field ***append);
+static void	word_filename_append(char *prefix, size_t prefix_len,
+				char *value, struct s_word_field ***append);
 
 /*
 	Match a pattern against files in the current directory and append matching
@@ -30,20 +30,24 @@ static void	word_filename_append(char *value, struct s_word_field ***append);
 	TODO: handle readdir error
 	TODO: report closedir error
 */
-void	word_filename(char	*pattern, struct s_word_field ***matches_append,
+void	word_filename(char	*pattern_str, struct s_word_field ***matches_append,
 	bool *had_matches)
 {
-	DIR					*dir;
-	struct dirent		*dirent;
+	struct s_word_pattern	pattern;
+	DIR						*dir;
+	struct dirent			*dirent;
 
 	*had_matches = false;
+	if (!word_pattern_init_filename(&pattern, pattern_str))
+		return ;
 	dir = opendir(".");
 	dirent = readdir(dir);
 	while (dirent)
 	{
-		if (word_filename_matches(dirent->d_name, pattern))
+		if (word_pattern_test_filename(&pattern, dirent->d_name))
 		{
-			word_filename_append(dirent->d_name, matches_append);
+			word_filename_append(pattern.prefix, pattern.prefix_len,
+				dirent->d_name, matches_append);
 			*had_matches = true;
 		}
 		dirent = readdir(dir);
@@ -52,29 +56,19 @@ void	word_filename(char	*pattern, struct s_word_field ***matches_append,
 }
 
 /*
-	Test whether a string matches a pattern.
-
-	TODO: implement real pattern matching, this is just for testing
-*/
-static bool	word_filename_matches(char *value, char *pattern)
-{
-	if (ft_strncmp(value, pattern, 2) == 0)
-		return (true);
-	return (false);
-}
-
-/*
 	Allocate a new field for string and append it to the list.
 */
-static void	word_filename_append(char *value, struct s_word_field ***append)
+static void	word_filename_append(char *prefix, size_t prefix_len,
+	char *value, struct s_word_field ***append)
 {
 	size_t				value_size;
 	struct s_word_field	*field;
 
 	value_size = ft_strlen(value) + 1;
-	field = malloc(sizeof(*field) + value_size);
+	field = malloc(sizeof(*field) + prefix_len + value_size);
 	field->next = NULL;
-	ft_memcpy(field->value, value, value_size);
+	ft_memcpy(field->value, prefix, prefix_len);
+	ft_memcpy(field->value + prefix_len, value, value_size);
 	**append = field;
 	*append = &field->next;
 }

--- a/src/word/word_internal.h
+++ b/src/word/word_internal.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/09 16:24:21 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/16 15:14:52 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/04/19 19:26:31 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,6 +31,14 @@ struct	s_word_state
 	bool				out_has_wildcard;
 };
 
+struct	s_word_pattern
+{
+	char	*pattern;
+	size_t	min_len;
+	char	*prefix;
+	size_t	prefix_len;
+};
+
 char	*word_exp_parse(char **word);
 
 void	word_filename(char	*pattern, struct s_word_field ***matches_append,
@@ -38,6 +46,9 @@ void	word_filename(char	*pattern, struct s_word_field ***matches_append,
 
 void	word_out_char(struct s_word_state *state, char c, bool quoted);
 void	word_out_split(struct s_word_state *state);
+
+bool	word_pattern_init_filename(struct s_word_pattern *pattern, char *str);
+bool	word_pattern_test_filename(struct s_word_pattern *pattern, char *str);
 
 void	word_scan(struct s_word_state *state);
 

--- a/src/word/word_pattern.c
+++ b/src/word/word_pattern.c
@@ -1,0 +1,147 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   word_pattern.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/19 16:26:57 by amakinen          #+#    #+#             */
+/*   Updated: 2025/04/19 19:37:25 by amakinen         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "word_internal.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "libft.h"
+
+/*
+	The inner matching functions don't use the pattern struct because character
+	matching advances position in pattern and candidate, while wildcard matching
+	needs to be able backtrack and retry from a previous position. Using
+	recursion and keeping the pointers in parameters is an easy way to do that.
+
+	TODO: Limit recursion to avoid stack overflow, or switch to explicit stack.
+*/
+
+static bool	word_pattern_match_characters(char *pattern, char *candidate,
+				size_t max_wildcard_len);
+static bool	word_pattern_match_wildcards(char *pattern, char *candidate,
+				size_t max_wildcard_len);
+
+/*
+	Initialize a pattern for matching against the given pattern string `str`.
+
+	The matching algorithm needs to know the minimum length of the pattern to
+	avoid testing excessively long wildcard matches that wouldn't allow the
+	rest of the pattern to match. Minimum length is the number of literal
+	characters, with a zero length match for each wildcard.
+
+	We also apply special rules for pathname expansion:
+	- Minishell doesn't traverse directories for pathname expansion, so patterns
+	with slashes will never match and can be rejected immediately.
+	- If the pattern begins with dot-slash elements, possibly with repeated
+	slashes, they refer to current directory and can be skipped to allow
+	matching to happen normally. The prefix is prepended to matches afterwards.
+*/
+bool	word_pattern_init_filename(struct s_word_pattern *pattern, char *str)
+{
+	size_t	min_len;
+
+	pattern->prefix = str;
+	while (str[0] == '.' && str[1] == '/')
+	{
+		str += 2;
+		while (str[0] == '/')
+			str++;
+	}
+	pattern->prefix_len = str - pattern->prefix;
+	pattern->pattern = str;
+	min_len = 0;
+	while (str[min_len])
+	{
+		while (str[min_len] == '*')
+			str++;
+		if (str[min_len] == INTERNAL_ESCAPE)
+			str++;
+		if (str[min_len] == '/')
+			return (false);
+		if (str[min_len])
+			min_len++;
+	}
+	pattern->min_len = min_len;
+	return (true);
+}
+
+/*
+	Test if the candidate `str` matches the pattern.
+
+	We apply a special rule for pathname expansion:
+	- Filenames beginning with a period `.` are considered hidden. A wildcard at
+	the start of a pattern will not match the initial period.
+*/
+bool	word_pattern_test_filename(struct s_word_pattern *pattern, char *str)
+{
+	size_t	candidate_len;
+	size_t	excess_len;
+
+	if (str[0] == '.' && pattern->pattern[0] == '*')
+		return (false);
+	candidate_len = ft_strlen(str);
+	if (candidate_len < pattern->min_len)
+		return (false);
+	excess_len = candidate_len - pattern->min_len;
+	return (word_pattern_match_characters(pattern->pattern, str, excess_len));
+}
+
+/*
+	Attempt to match literal characters in candidate to the pattern. Wildcard
+	characters in pattern are skipped and a helper function tries different
+	wildcard lengths. If literal characters don't match, reject the candidate.
+	If end of the candidate and the pattern is reached, accept the candidate.
+*/
+static bool	word_pattern_match_characters(char *pattern, char *candidate,
+	size_t max_wildcard_len)
+{
+	while (true)
+	{
+		if (*pattern == '*')
+			return (word_pattern_match_wildcards(pattern + 1, candidate,
+					max_wildcard_len));
+		if (*pattern == INTERNAL_ESCAPE)
+			pattern++;
+		if (*pattern != *candidate)
+			return (false);
+		if (!*pattern)
+			return (true);
+		pattern++;
+		candidate++;
+	}
+}
+
+/*
+	Attempt the longest possible match for a wildcard and check if the rest of
+	the pattern matches. If it doesn't, repeat with a shorter matches for the
+	wildcard down to a zero-length match. If even a zero-length match doesn't
+	allow the rest of the pattern to match, reject the candidate.
+
+	Consecutive wildcards are combined into this one as their individual lenghts
+	don't affect the result and processing them individually would exponentially
+	ncrease the number of attempts before rejection.
+*/
+static bool	word_pattern_match_wildcards(char *pattern, char *candidate,
+	size_t max_wildcard_len)
+{
+	size_t	wildcard_len;
+
+	while (*pattern == '*')
+		pattern++;
+	wildcard_len = max_wildcard_len + 1;
+	while (wildcard_len--)
+		if (word_pattern_match_characters(pattern, candidate + wildcard_len,
+				max_wildcard_len - wildcard_len))
+			return (true);
+	return (false);
+}


### PR DESCRIPTION
Should be nothing strange in the pattern matching code itself, but one thing that I realized here is the potential for stack overflow with recursion. We should limit recursion depth to avoid stack overflow, not just here but everywhere where we use recursion.