### PR TITLE
Error handling improvements

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 12:50:10 by josmanov          #+#    #+#             */
-/*   Updated: 2025/04/07 16:56:10 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 20:12:04 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,15 +14,8 @@
 # define PARSER_H
 
 # include "ast.h"
+# include "status.h"
 
-enum	e_parser_status
-{
-	PARSER_SUCCESS,
-	PARSER_ERR_SYNTAX,
-	PARSER_ERR_MALLOC,
-};
-
-enum e_parser_status	parser_parse(char *line,
-							struct s_ast_list_entry **root);
+t_status	parser_parse(char *line, struct s_ast_list_entry **root);
 
 #endif

--- a/include/status.h
+++ b/include/status.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 21:50:28 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/27 21:40:16 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 19:06:48 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,6 +43,12 @@ typedef enum e_status
 	S_RESET_SIGINT,
 	S_COMM_ERR,
 }	t_status;
+
+/*
+	Predefined error messages that are used in many places in the codebase.
+*/
+
+# define ERRMSG_MALLOC "memory allocation failed"
 
 /*
 	Print an error message to stderr and return a status code. Useful for

--- a/include/word.h
+++ b/include/word.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/28 16:50:15 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/09 18:22:33 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 21:49:37 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,6 @@ struct s_word_field
 t_status	word_expand(char *word, struct s_word_field **fields_out);
 
 bool		word_heredoc_delimiter(char *word);
-char		*word_heredoc_line(char *line);
+t_status	word_heredoc_line(char **line);
 
 #endif

--- a/include/word.h
+++ b/include/word.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/28 16:50:15 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/16 15:54:21 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/09 18:22:33 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,8 @@
 # define WORD_H
 
 # include <stdbool.h>
+
+# include "status.h"
 
 /*
 	Field resulting from word expansion, allocated as a single block with enough
@@ -25,9 +27,9 @@ struct s_word_field
 	char				value[];
 };
 
-struct s_word_field	*word_expand(char *word);
+t_status	word_expand(char *word, struct s_word_field **fields_out);
 
-bool				word_heredoc_delimiter(char *word);
-char				*word_heredoc_line(char *line);
+bool		word_heredoc_delimiter(char *word);
+char		*word_heredoc_line(char *line);
 
 #endif

--- a/src/env/get_set.c
+++ b/src/env/get_set.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   get_set.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 02:15:43 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 19:33:57 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/05/14 18:10:04 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,7 +63,7 @@ t_status	env_set(t_env *env, const char *key, const char *value)
 	value_len = ft_strlen(value);
 	new_entry = create_env_string(key, key_len, value, value_len);
 	if (!new_entry)
-		return (status_err(S_RESET_ERR, "malloc", NULL, 0));
+		return (status_err(S_EXIT_ERR, ERRMSG_MALLOC, NULL, 0));
 	if (env_find_index(env, key, key_len, &index))
 		return (update_existing_entry(env, index, new_entry));
 	return (add_new_entry(env, new_entry));

--- a/src/env/init.c
+++ b/src/env/init.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 01:34:15 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/14 18:11:02 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/14 18:15:38 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,29 +33,18 @@ static t_status	init_env_array(t_env *env, int size)
 	return (S_OK);
 }
 
-static char	*ft_strdup_env(const char *s)
-{
-	char	*new;
-	size_t	len;
-
-	len = ft_strlen(s);
-	new = malloc(len + 1);
-	if (!new)
-		return (NULL);
-	ft_memcpy(new, s, len + 1);
-	return (new);
-}
-
 static t_status	copy_environ_to_env(t_env *env)
 {
 	int			i;
 	char		*value;
 	t_status	status;
 
+	if (!environ)
+		return (S_OK);
 	i = 0;
 	while (environ[i])
 	{
-		value = ft_strdup_env(environ[i]);
+		value = ft_strdup(environ[i]);
 		if (!value)
 			return (status_err(S_EXIT_ERR, ERRMSG_MALLOC, NULL, 0));
 		status = env_resize(env);

--- a/src/env/init.c
+++ b/src/env/init.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   init.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 01:34:15 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 19:45:34 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/05/14 18:11:02 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,7 +57,7 @@ static t_status	copy_environ_to_env(t_env *env)
 	{
 		value = ft_strdup_env(environ[i]);
 		if (!value)
-			return (status_err(S_RESET_ERR, "malloc", NULL, 0));
+			return (status_err(S_EXIT_ERR, ERRMSG_MALLOC, NULL, 0));
 		status = env_resize(env);
 		if (status != S_OK)
 		{

--- a/src/env/utils.c
+++ b/src/env/utils.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 01:54:36 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/14 18:10:05 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/14 18:15:04 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -73,9 +73,4 @@ t_status	env_resize(t_env *env)
 	env->env_array = new_array;
 	env->array_size = new_size;
 	return (S_OK);
-}
-
-char	**env_get_array(t_env *env)
-{
-	return (env->env_array);
 }

--- a/src/env/utils.c
+++ b/src/env/utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   utils.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 01:54:36 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 19:45:43 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/05/14 18:10:05 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,6 +37,11 @@ bool	env_find_index(t_env *env, const char *key,
 	return (false);
 }
 
+/*
+	Allocate a string for an environment value. Due to limit of four arguments,
+	returns a pointer (NULL on allocation failure) instead of t_status. Caller
+	must check the pointer and report allocation error if it is NULL.
+*/
 char	*create_env_string(const char *key, size_t key_len,
 		const char *value, size_t value_len)
 {
@@ -61,7 +66,7 @@ t_status	env_resize(t_env *env)
 	new_size = env->array_size * 2;
 	new_array = malloc(sizeof(char *) * (new_size + 1));
 	if (!new_array)
-		return (status_err(S_RESET_ERR, "malloc", NULL, 0));
+		return (status_err(S_EXIT_ERR, ERRMSG_MALLOC, NULL, 0));
 	ft_memcpy(new_array, env->env_array, sizeof(char *) * env->used_size);
 	new_array[env->used_size] = NULL;
 	free(env->env_array);

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/11 15:55:33 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/01 22:19:37 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/05/12 20:28:40 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,12 +30,11 @@ int	main(void)
 {
 	char					*line;
 	struct s_ast_list_entry	*ast;
-	enum e_parser_status	status;
+	t_status				status;
 	t_env					env;
-	t_status				env_status;
 
-	env_status = env_init(&env);
-	if (env_status != S_OK)
+	status = env_init(&env);
+	if (status != S_OK)
 		return (1);
 	while (1)
 	{
@@ -43,13 +42,13 @@ int	main(void)
 		if (!line)
 			break ;
 		status = parser_parse(line, &ast);
-		if (status == PARSER_SUCCESS && ast)
+		if (status == S_OK && ast)
 			add_history(line);
 		free(line);
-		if (status == PARSER_SUCCESS)
+		if (status == S_OK)
 			execute_list(ast, &env);
 		free_ast(ast);
-		if (status == PARSER_ERR_MALLOC)
+		if (status == S_EXIT_ERR)
 			return (1);
 	}
 	env_free(&env);

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 01:58:09 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 20:21:41 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 22:44:04 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,9 +40,6 @@ t_status	parser_parse(char *line, struct s_ast_list_entry **root)
 	if (state.curr_tok.type != TOK_END)
 		status = parser_list(&state, root);
 	if (status == S_OK && state.curr_tok.type != TOK_END)
-	{
-		parser_syntax_error("unexpected token");
-		status = S_RESET_SYNTAX;
-	}
+		return (parser_syntax_error("unexpected token"));
 	return (status);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 01:58:09 by josmanov          #+#    #+#             */
-/*   Updated: 2025/04/07 16:57:24 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 20:21:41 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@
 #include <stddef.h>
 
 #include "ast.h"
+#include "status.h"
 #include "tokenizer.h"
 
 void	parser_next_token(struct s_parser_state *state)
@@ -27,21 +28,21 @@ void	parser_next_token(struct s_parser_state *state)
 	Top-level parsing function. Parses a complete command line.
 	Stores the created AST in the pointer pointed to by `root`.
 */
-enum e_parser_status	parser_parse(char *line, struct s_ast_list_entry **root)
+t_status	parser_parse(char *line, struct s_ast_list_entry **root)
 {
-	enum e_parser_status	status;
+	t_status				status;
 	struct s_parser_state	state;
 
 	state.tok_state.line_pos = line;
 	parser_next_token(&state);
 	*root = NULL;
-	status = PARSER_SUCCESS;
+	status = S_OK;
 	if (state.curr_tok.type != TOK_END)
 		status = parser_list(&state, root);
-	if (status == PARSER_SUCCESS && state.curr_tok.type != TOK_END)
+	if (status == S_OK && state.curr_tok.type != TOK_END)
 	{
 		parser_syntax_error("unexpected token");
-		status = PARSER_ERR_SYNTAX;
+		status = S_RESET_SYNTAX;
 	}
 	return (status);
 }

--- a/src/parser/parser_group.c
+++ b/src/parser/parser_group.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 01:58:24 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 21:36:54 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 22:43:45 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,10 +31,7 @@ t_status	parser_group(
 	if (status != S_OK)
 		return (status);
 	if (state->curr_tok.type != TOK_GROUP_END)
-	{
-		parser_syntax_error("expected closing parenthesis");
-		return (S_RESET_SYNTAX);
-	}
+		return (parser_syntax_error("expected closing parenthesis"));
 	parser_next_token(state);
 	return (S_OK);
 }

--- a/src/parser/parser_group.c
+++ b/src/parser/parser_group.c
@@ -6,35 +6,35 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 01:58:24 by josmanov          #+#    #+#             */
-/*   Updated: 2025/04/02 16:08:48 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 21:36:54 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser_internal.h"
 
 #include "ast.h"
-#include "parser.h"
+#include "status.h"
 #include "tokenizer.h"
 
 /*
 	Parses a group (commands inside parentheses) from the token list.
 	Next token must be TOK_GROUP_START.
 */
-enum e_parser_status	parser_group(
+t_status	parser_group(
 	struct s_parser_state *state,
 	struct s_ast_list_entry **group_head)
 {
-	enum e_parser_status		status;
+	t_status	status;
 
 	parser_next_token(state);
 	status = parser_list(state, group_head);
-	if (status != PARSER_SUCCESS)
+	if (status != S_OK)
 		return (status);
 	if (state->curr_tok.type != TOK_GROUP_END)
 	{
 		parser_syntax_error("expected closing parenthesis");
-		return (PARSER_ERR_SYNTAX);
+		return (S_RESET_SYNTAX);
 	}
 	parser_next_token(state);
-	return (PARSER_SUCCESS);
+	return (S_OK);
 }

--- a/src/parser/parser_heredoc.c
+++ b/src/parser/parser_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/19 13:40:32 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 21:51:52 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 22:26:54 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,7 +42,7 @@ static t_status	add_line_to_heredoc(
 
 	new_line = malloc(sizeof(*new_line));
 	if (!new_line)
-		return (S_EXIT_ERR);
+		return (status_err(S_EXIT_ERR, ERRMSG_MALLOC, NULL, 0));
 	new_line->word = line;
 	new_line->next = NULL;
 	**lines_append = new_line;

--- a/src/parser/parser_heredoc.c
+++ b/src/parser/parser_heredoc.c
@@ -3,18 +3,21 @@
 /*                                                        :::      ::::::::   */
 /*   parser_heredoc.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/19 13:40:32 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/10 22:42:03 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/05/12 20:20:15 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser_internal.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <readline/readline.h>
+
 #include "libft.h"
+#include "status.h"
 #include "word.h"
 
 /*
@@ -31,7 +34,7 @@ static bool	is_delimiter(char *line, char *delimiter, size_t delim_len)
 /*
 	Add a line to the heredoc lines list
 */
-static enum e_parser_status	add_line_to_heredoc(
+static t_status	add_line_to_heredoc(
 	struct s_ast_command_word ***lines_append,
 	char *line)
 {
@@ -39,28 +42,28 @@ static enum e_parser_status	add_line_to_heredoc(
 
 	new_line = malloc(sizeof(*new_line));
 	if (!new_line)
-		return (PARSER_ERR_MALLOC);
+		return (S_EXIT_ERR);
 	new_line->word = line;
 	new_line->next = NULL;
 	**lines_append = new_line;
 	*lines_append = &new_line->next;
-	return (PARSER_SUCCESS);
+	return (S_OK);
 }
 
 /*
 	Process a line for the heredoc
 */
-static enum e_parser_status	process_heredoc_line(
+static t_status	process_heredoc_line(
 	struct s_heredoc_params *params)
 {
-	enum e_parser_status	status;
+	t_status	status;
 
 	if (!params->quoted)
 		params->line = word_heredoc_line(params->line);
 	if (!params->line)
-		return (PARSER_ERR_MALLOC);
+		return (S_EXIT_ERR);
 	status = add_line_to_heredoc(&params->lines_append, params->line);
-	if (status != PARSER_SUCCESS)
+	if (status != S_OK)
 		free(params->line);
 	return (status);
 }
@@ -69,18 +72,18 @@ static enum e_parser_status	process_heredoc_line(
 	Read heredoc content from stdin until the delimiter is encountered.
 	Store the content as a linked list of lines in the redirect node.
 */
-enum e_parser_status	read_heredoc(struct s_ast_redirect *redirect)
+t_status	read_heredoc(struct s_ast_redirect *redirect)
 {
-	struct s_heredoc_params		params;
-	enum e_parser_status		status;
+	struct s_heredoc_params	params;
+	t_status				status;
 
 	redirect->heredoc_lines = NULL;
 	params.lines_append = &redirect->heredoc_lines;
 	params.quoted = word_heredoc_delimiter(redirect->word);
 	params.delimiter = redirect->word;
 	params.delim_len = ft_strlen(redirect->word);
-	status = PARSER_SUCCESS;
-	while (status == PARSER_SUCCESS)
+	status = S_OK;
+	while (status == S_OK)
 	{
 		params.line = readline("> ");
 		if (!params.line)

--- a/src/parser/parser_heredoc.c
+++ b/src/parser/parser_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/19 13:40:32 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 20:20:15 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 21:51:52 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,11 +58,11 @@ static t_status	process_heredoc_line(
 {
 	t_status	status;
 
+	status = S_OK;
 	if (!params->quoted)
-		params->line = word_heredoc_line(params->line);
-	if (!params->line)
-		return (S_EXIT_ERR);
-	status = add_line_to_heredoc(&params->lines_append, params->line);
+		status = word_heredoc_line(&params->line);
+	if (status == S_OK)
+		status = add_line_to_heredoc(&params->lines_append, params->line);
 	if (status != S_OK)
 		free(params->line);
 	return (status);

--- a/src/parser/parser_internal.h
+++ b/src/parser/parser_internal.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 16:49:57 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/12 21:39:07 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 22:43:47 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,6 +62,6 @@ t_status	read_heredoc(struct s_ast_redirect *redirect);
 
 /* Error handling helper */
 
-void		parser_syntax_error(const char *message);
+t_status	parser_syntax_error(const char *message);
 
 #endif

--- a/src/parser/parser_internal.h
+++ b/src/parser/parser_internal.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser_internal.h                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 16:49:57 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/10 22:25:12 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/05/12 21:39:07 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,9 @@
 # define PARSER_INTERNAL_H
 
 # include <stddef.h>
-# include "parser.h"
+
 # include "ast.h"
+# include "status.h"
 # include "tokenizer.h"
 
 struct	s_parser_state
@@ -24,28 +25,28 @@ struct	s_parser_state
 	struct s_tokenizer_state	tok_state;
 };
 
-void					parser_next_token(struct s_parser_state *state);
+void		parser_next_token(struct s_parser_state *state);
 
 /* Command parsing functions */
 
-enum e_parser_status	parser_word(
-							struct s_parser_state *state,
-							struct s_ast_command_word **word);
-enum e_parser_status	parser_redirect(
-							struct s_parser_state *state,
-							struct s_ast_redirect **redirect);
-enum e_parser_status	parser_simple_command(
-							struct s_parser_state *state,
-							struct s_ast_simple_command **simple_command);
-enum e_parser_status	parser_pipeline(
-							struct s_parser_state *state,
-							struct s_ast_simple_command **pipeline_head);
-enum e_parser_status	parser_list(
-							struct s_parser_state *state,
-							struct s_ast_list_entry **list_head);
-enum e_parser_status	parser_group(
-							struct s_parser_state *state,
-							struct s_ast_list_entry **group_head);
+t_status	parser_word(
+				struct s_parser_state *state,
+				struct s_ast_command_word **word);
+t_status	parser_redirect(
+				struct s_parser_state *state,
+				struct s_ast_redirect **redirect);
+t_status	parser_simple_command(
+				struct s_parser_state *state,
+				struct s_ast_simple_command **simple_command);
+t_status	parser_pipeline(
+				struct s_parser_state *state,
+				struct s_ast_simple_command **pipeline_head);
+t_status	parser_list(
+				struct s_parser_state *state,
+				struct s_ast_list_entry **list_head);
+t_status	parser_group(
+				struct s_parser_state *state,
+				struct s_ast_list_entry **group_head);
 
 /* Heredoc handling */
 struct s_heredoc_params
@@ -57,10 +58,10 @@ struct s_heredoc_params
 	size_t						delim_len;
 };
 
-enum e_parser_status	read_heredoc(struct s_ast_redirect *redirect);
+t_status	read_heredoc(struct s_ast_redirect *redirect);
 
 /* Error handling helper */
 
-void					parser_syntax_error(const char *message);
+void		parser_syntax_error(const char *message);
 
 #endif

--- a/src/parser/parser_list.c
+++ b/src/parser/parser_list.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/01 14:22:36 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 21:41:00 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 22:26:54 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,7 +31,7 @@ static t_status	parser_list_entry(
 
 	new_entry = malloc(sizeof(*new_entry));
 	if (!new_entry)
-		return (S_EXIT_ERR);
+		return (status_err(S_EXIT_ERR, ERRMSG_MALLOC, NULL, 0));
 	*list_append = new_entry;
 	new_entry->next = NULL;
 	if (state->curr_tok.type == TOK_GROUP_START)

--- a/src/parser/parser_list.c
+++ b/src/parser/parser_list.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/01 14:22:36 by josmanov          #+#    #+#             */
-/*   Updated: 2025/04/02 16:08:48 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 21:41:00 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,23 +15,23 @@
 #include <stdlib.h>
 
 #include "ast.h"
-#include "parser.h"
+#include "status.h"
 #include "tokenizer.h"
 
 /*
 	Parses a single list entry from the token list.
 	A list entry can be either a pipeline or a group.
 */
-static enum e_parser_status	parser_list_entry(
+static t_status	parser_list_entry(
 	struct s_parser_state *state,
 	struct s_ast_list_entry **list_append)
 {
-	enum e_parser_status		status;
-	struct s_ast_list_entry		*new_entry;
+	t_status				status;
+	struct s_ast_list_entry	*new_entry;
 
 	new_entry = malloc(sizeof(*new_entry));
 	if (!new_entry)
-		return (PARSER_ERR_MALLOC);
+		return (S_EXIT_ERR);
 	*list_append = new_entry;
 	new_entry->next = NULL;
 	if (state->curr_tok.type == TOK_GROUP_START)
@@ -52,18 +52,18 @@ static enum e_parser_status	parser_list_entry(
 /*
 	Parses a list of commands separated by && or || operators.
 */
-enum e_parser_status	parser_list(
+t_status	parser_list(
 	struct s_parser_state *state,
 	struct s_ast_list_entry **list_head)
 {
-	enum e_parser_status	status;
+	t_status				status;
 	struct s_ast_list_entry	**list_append;
 
 	list_append = list_head;
 	while (1)
 	{
 		status = parser_list_entry(state, list_append);
-		if (status != PARSER_SUCCESS)
+		if (status != S_OK)
 			return (status);
 		if (state->curr_tok.type == TOK_AND)
 			(*list_append)->next_op = AST_LIST_AND;
@@ -74,5 +74,5 @@ enum e_parser_status	parser_list(
 		parser_next_token(state);
 		list_append = &((*list_append)->next);
 	}
-	return (PARSER_SUCCESS);
+	return (S_OK);
 }

--- a/src/parser/parser_pipeline.c
+++ b/src/parser/parser_pipeline.c
@@ -6,37 +6,37 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/15 14:22:31 by josmanov          #+#    #+#             */
-/*   Updated: 2025/04/02 16:08:48 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 21:41:05 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser_internal.h"
 
 #include "ast.h"
-#include "parser.h"
+#include "status.h"
 #include "tokenizer.h"
 
 /*
 	Parses a pipeline from the token list.
 	Pipelines consist of simple commands separated by pipe state.
 */
-enum e_parser_status	parser_pipeline(
+t_status	parser_pipeline(
 	struct s_parser_state *state,
 	struct s_ast_simple_command **pipeline_head)
 {
-	enum e_parser_status		status;
+	t_status					status;
 	struct s_ast_simple_command	**pipeline_append;
 
 	pipeline_append = pipeline_head;
 	while (1)
 	{
 		status = parser_simple_command(state, pipeline_append);
-		if (status != PARSER_SUCCESS)
+		if (status != S_OK)
 			return (status);
 		if (state->curr_tok.type != TOK_PIPE)
 			break ;
 		parser_next_token(state);
 		pipeline_append = &((*pipeline_append)->next);
 	}
-	return (PARSER_SUCCESS);
+	return (S_OK);
 }

--- a/src/parser/parser_redirect.c
+++ b/src/parser/parser_redirect.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser_redirect.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/01 11:22:25 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/10 22:33:23 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/05/12 21:41:10 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
 #include <stdlib.h>
 
 #include "ast.h"
-#include "parser.h"
+#include "status.h"
 #include "tokenizer.h"
 
 static enum e_ast_redirect_op	redirect_token_to_op(enum e_token type)
@@ -34,16 +34,16 @@ static enum e_ast_redirect_op	redirect_token_to_op(enum e_token type)
 	Parses a redirect and adds it to the AST.
 	Next token must be a redirect token.
 */
-enum e_parser_status	parser_redirect(
+t_status	parser_redirect(
 	struct s_parser_state *state,
 	struct s_ast_redirect **redirect)
 {
-	enum e_parser_status	status;
+	t_status				status;
 	struct s_ast_redirect	*new_redirect;
 
 	new_redirect = malloc(sizeof(*new_redirect));
 	if (!new_redirect)
-		return (PARSER_ERR_MALLOC);
+		return (S_EXIT_ERR);
 	new_redirect->next = NULL;
 	new_redirect->heredoc_lines = NULL;
 	new_redirect->op = redirect_token_to_op(state->curr_tok.type);
@@ -52,12 +52,12 @@ enum e_parser_status	parser_redirect(
 	{
 		free(new_redirect);
 		parser_syntax_error("expected word after redirect");
-		return (PARSER_ERR_SYNTAX);
+		return (S_RESET_SYNTAX);
 	}
 	new_redirect->word = state->curr_tok.word_content;
 	parser_next_token(state);
 	*redirect = new_redirect;
-	status = PARSER_SUCCESS;
+	status = S_OK;
 	if (new_redirect->op == AST_HEREDOC)
 		status = read_heredoc(new_redirect);
 	return (status);

--- a/src/parser/parser_redirect.c
+++ b/src/parser/parser_redirect.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/01 11:22:25 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 22:32:25 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 22:43:52 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,19 +44,15 @@ t_status	parser_redirect(
 	new_redirect = malloc(sizeof(*new_redirect));
 	if (!new_redirect)
 		return (status_err(S_EXIT_ERR, ERRMSG_MALLOC, NULL, 0));
+	*redirect = new_redirect;
 	new_redirect->next = NULL;
 	new_redirect->heredoc_lines = NULL;
 	new_redirect->op = redirect_token_to_op(state->curr_tok.type);
 	parser_next_token(state);
 	if (state->curr_tok.type != TOK_WORD)
-	{
-		free(new_redirect);
-		parser_syntax_error("expected word after redirect");
-		return (S_RESET_SYNTAX);
-	}
+		return (parser_syntax_error("expected word after redirect"));
 	new_redirect->word = state->curr_tok.word_content;
 	parser_next_token(state);
-	*redirect = new_redirect;
 	status = S_OK;
 	if (new_redirect->op == AST_HEREDOC)
 		status = read_heredoc(new_redirect);

--- a/src/parser/parser_redirect.c
+++ b/src/parser/parser_redirect.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/01 11:22:25 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 21:41:10 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 22:32:25 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,7 +43,7 @@ t_status	parser_redirect(
 
 	new_redirect = malloc(sizeof(*new_redirect));
 	if (!new_redirect)
-		return (S_EXIT_ERR);
+		return (status_err(S_EXIT_ERR, ERRMSG_MALLOC, NULL, 0));
 	new_redirect->next = NULL;
 	new_redirect->heredoc_lines = NULL;
 	new_redirect->op = redirect_token_to_op(state->curr_tok.type);

--- a/src/parser/parser_simple_command.c
+++ b/src/parser/parser_simple_command.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 01:53:36 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 21:41:14 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 22:31:09 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,7 +77,7 @@ t_status	parser_simple_command(
 
 	new_command = malloc(sizeof(*new_command));
 	if (!new_command)
-		return (S_EXIT_ERR);
+		return (status_err(S_EXIT_ERR, ERRMSG_MALLOC, NULL, 0));
 	*simple_command = new_command;
 	new_command->next = NULL;
 	new_command->args = NULL;

--- a/src/parser/parser_simple_command.c
+++ b/src/parser/parser_simple_command.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 01:53:36 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 22:31:09 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 22:43:59 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -86,9 +86,6 @@ t_status	parser_simple_command(
 	if (status != S_OK)
 		return (status);
 	if (new_command->args == NULL && new_command->redirs == NULL)
-	{
-		parser_syntax_error("expected word or redirect");
-		return (S_RESET_SYNTAX);
-	}
+		return (parser_syntax_error("expected word or redirect"));
 	return (S_OK);
 }

--- a/src/parser/parser_simple_command.c
+++ b/src/parser/parser_simple_command.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 01:53:36 by josmanov          #+#    #+#             */
-/*   Updated: 2025/04/02 16:08:49 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 21:41:14 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,7 @@
 #include <stdlib.h>
 
 #include "ast.h"
-#include "parser.h"
+#include "status.h"
 #include "tokenizer.h"
 
 static bool	is_redirect_token(struct s_parser_state *state)
@@ -35,11 +35,11 @@ static bool	is_redirect_token(struct s_parser_state *state)
 /*
 	Process elements of a command (words and redirections).
 */
-static enum e_parser_status	process_command_elements(
+static t_status	process_command_elements(
 	struct s_parser_state *state,
 	struct s_ast_simple_command *new_command)
 {
-	enum e_parser_status		status;
+	t_status					status;
 	struct s_ast_command_word	**args_append;
 	struct s_ast_redirect		**redirs_append;
 
@@ -50,45 +50,45 @@ static enum e_parser_status	process_command_elements(
 		if (is_redirect_token(state))
 		{
 			status = parser_redirect(state, redirs_append);
-			if (status != PARSER_SUCCESS)
+			if (status != S_OK)
 				return (status);
 			redirs_append = &(*redirs_append)->next;
 		}
 		else
 		{
 			status = parser_word(state, args_append);
-			if (status != PARSER_SUCCESS)
+			if (status != S_OK)
 				return (status);
 			args_append = &(*args_append)->next;
 		}
 	}
-	return (PARSER_SUCCESS);
+	return (S_OK);
 }
 
 /*
 	Parses a simple command from the token list.
 */
-enum e_parser_status	parser_simple_command(
+t_status	parser_simple_command(
 	struct s_parser_state *state,
 	struct s_ast_simple_command **simple_command)
 {
-	enum e_parser_status		status;
+	t_status					status;
 	struct s_ast_simple_command	*new_command;
 
 	new_command = malloc(sizeof(*new_command));
 	if (!new_command)
-		return (PARSER_ERR_MALLOC);
+		return (S_EXIT_ERR);
 	*simple_command = new_command;
 	new_command->next = NULL;
 	new_command->args = NULL;
 	new_command->redirs = NULL;
 	status = process_command_elements(state, new_command);
-	if (status != PARSER_SUCCESS)
+	if (status != S_OK)
 		return (status);
 	if (new_command->args == NULL && new_command->redirs == NULL)
 	{
 		parser_syntax_error("expected word or redirect");
-		return (PARSER_ERR_SYNTAX);
+		return (S_RESET_SYNTAX);
 	}
-	return (PARSER_SUCCESS);
+	return (S_OK);
 }

--- a/src/parser/parser_syntax_error.c
+++ b/src/parser/parser_syntax_error.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 12:22:58 by josmanov          #+#    #+#             */
-/*   Updated: 2025/03/31 20:47:55 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 22:44:01 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,14 @@
 
 #include <stdio.h>
 
-void	parser_syntax_error(const char *message)
+#include "status.h"
+
+/*
+	Report a syntax error.
+
+	TODO: print expected and actual tokens, or position in input
+*/
+t_status	parser_syntax_error(const char *message)
 {
-	fprintf(stderr, "minishell: syntax error: %s\n", message);
+	return (status_err(S_RESET_SYNTAX, "syntax error", message, 0));
 }

--- a/src/parser/parser_word.c
+++ b/src/parser/parser_word.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/01 11:22:25 by josmanov          #+#    #+#             */
-/*   Updated: 2025/04/02 16:05:41 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 21:41:41 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,13 +15,13 @@
 #include <stdlib.h>
 
 #include "ast.h"
-#include "parser.h"
+#include "status.h"
 
 /*
 	Parses a word and adds it to the AST.
 	Next token must be TOK_WORD.
 */
-enum e_parser_status	parser_word(
+t_status	parser_word(
 	struct s_parser_state *state,
 	struct s_ast_command_word **word)
 {
@@ -29,10 +29,10 @@ enum e_parser_status	parser_word(
 
 	new_word = malloc(sizeof(*new_word));
 	if (!new_word)
-		return (PARSER_ERR_MALLOC);
+		return (S_EXIT_ERR);
 	*word = new_word;
 	new_word->next = NULL;
 	new_word->word = state->curr_tok.word_content;
 	parser_next_token(state);
-	return (PARSER_SUCCESS);
+	return (S_OK);
 }

--- a/src/parser/parser_word.c
+++ b/src/parser/parser_word.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/01 11:22:25 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 21:41:41 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 22:26:54 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,7 @@ t_status	parser_word(
 
 	new_word = malloc(sizeof(*new_word));
 	if (!new_word)
-		return (S_EXIT_ERR);
+		return (status_err(S_EXIT_ERR, ERRMSG_MALLOC, NULL, 0));
 	*word = new_word;
 	new_word->next = NULL;
 	new_word->word = state->curr_tok.word_content;

--- a/src/status.c
+++ b/src/status.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/26 20:11:15 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/09 18:53:14 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/14 18:55:48 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,25 +28,48 @@ t_status	status_err(t_status status,
 /*
 	We want to avoid using malloc as this might be called after malloc failure.
 	We should make the local buffer large enough for all the error messages we
-	might print, but with strlcpy we'll at least be safe from buffer overflows.
+	might print, but check to be safe.
 */
 #define ERR_BUF_LEN 1000
+
+/*
+	Append to buffer and calculate new length.
+
+	Using strlcpy avoids writing outside the buffer, but we can't blindly add
+	the returned length as it might be larger than fits or even overflow the
+	addition.
+
+	By passing the buffer as pointer-to-array the compiler ensures the caller
+	uses appropriate size.
+*/
+static size_t	status_msg_append(char (*buf)[ERR_BUF_LEN], size_t len,
+	const char *str)
+{
+	size_t	added_len;
+
+	added_len = ft_strlcpy(*buf + len, str, sizeof(*buf) - len);
+	if (added_len < sizeof(*buf) - len)
+		return (len + added_len);
+	else
+		return (sizeof(*buf) - 1);
+}
 
 void	status_warn(const char *msg, const char *extra, int errnum)
 {
 	char	buf[ERR_BUF_LEN];
 	size_t	len;
 
-	len = ft_strlcpy(buf, msg, ERR_BUF_LEN);
+	len = status_msg_append(&buf, 0, "minishell: ");
+	len = status_msg_append(&buf, len, msg);
 	if (extra)
 	{
-		len += ft_strlcpy(buf + len, ": ", ERR_BUF_LEN - len);
-		len += ft_strlcpy(buf + len, extra, ERR_BUF_LEN - len);
+		len = status_msg_append(&buf, len, ": ");
+		len = status_msg_append(&buf, len, extra);
 	}
 	if (errnum != 0)
 	{
-		len += ft_strlcpy(buf + len, ": ", ERR_BUF_LEN - len);
-		len += ft_strlcpy(buf + len, strerror(errnum), ERR_BUF_LEN - len);
+		len = status_msg_append(&buf, len, ": ");
+		len = status_msg_append(&buf, len, strerror(errnum));
 	}
 	buf[len++] = '\n';
 	util_write_all(STDERR_FILENO, buf, len);

--- a/src/status.c
+++ b/src/status.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/26 20:11:15 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/27 21:30:00 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/09 18:53:14 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,5 +48,6 @@ void	status_warn(const char *msg, const char *extra, int errnum)
 		len += ft_strlcpy(buf + len, ": ", ERR_BUF_LEN - len);
 		len += ft_strlcpy(buf + len, strerror(errnum), ERR_BUF_LEN - len);
 	}
+	buf[len++] = '\n';
 	util_write_all(STDERR_FILENO, buf, len);
 }

--- a/src/test/heredoc.c
+++ b/src/test/heredoc.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   heredoc.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 10:32:56 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/10 22:33:37 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/05/12 20:22:02 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@
 #define RESET "\033[0m"
 
 /* Function declarations */
-enum e_parser_status	read_heredoc(struct s_ast_redirect *redirect);
+t_status	read_heredoc(struct s_ast_redirect *redirect);
 
 /* Print test result */
 static void	print_result(const char *name, bool passed)
@@ -140,14 +140,14 @@ static void	test_heredoc_parser(void)
 {
 	struct s_ast_redirect	redirect;
 	char					*delimiter;
-	enum e_parser_status	status;
+	t_status				status;
 	bool					success;
 
 	delimiter = setup_heredoc_test(&redirect);
 	if (!delimiter)
 		return ;
 	status = read_heredoc(&redirect);
-	success = (status == PARSER_SUCCESS);
+	success = (status == S_OK);
 	print_result("heredoc_parser", success);
 	if (!success || !redirect.heredoc_lines)
 	{

--- a/src/test/input_parser.c
+++ b/src/test/input_parser.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/02 16:17:11 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/07 17:02:32 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 21:32:40 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,7 @@
 #include <readline/readline.h>
 
 #include "ast.h"
+#include "status.h"
 #include "parser.h"
 
 #define INDENT_STEP 4
@@ -101,7 +102,7 @@ static void	print_list(struct s_ast_list_entry *list, int indent)
 
 int	main(void)
 {
-	enum e_parser_status	ps;
+	t_status				status;
 	struct s_ast_list_entry	*root;
 	char					*line;
 
@@ -110,14 +111,11 @@ int	main(void)
 		line = readline("input parser> ");
 		if (!line)
 			break ;
-		ps = parser_parse(line, &root);
-		if (ps == PARSER_ERR_MALLOC)
-		{
-			printf("malloc error\n");
-			return (1);
-		}
-		if (ps == PARSER_ERR_SYNTAX)
+		status = parser_parse(line, &root);
+		if (status == S_RESET_SYNTAX || status == S_RESET_SIGINT)
 			printf("try again\n");
+		else if (status != S_OK)
+			return (1);
 		else if (!root)
 			printf("empty command\n");
 		else

--- a/src/test/wordexp.c
+++ b/src/test/wordexp.c
@@ -6,13 +6,14 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/04 17:56:49 by amakinen          #+#    #+#             */
-/*   Updated: 2025/03/04 18:47:55 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/09 18:35:56 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "status.h"
 #include "word.h"
 
 int	main(int argc, char **argv)
@@ -20,19 +21,23 @@ int	main(int argc, char **argv)
 	int					i;
 	struct s_word_field	*fields;
 	struct s_word_field	*next;
+	t_status			status;
 
 	i = 1;
 	while (i < argc)
 	{
 		printf("\e[31mWord  : \e[91m%s\e[0m\n", argv[i]);
-		fields = word_expand(argv[i]);
+		status = word_expand(argv[i], &fields);
 		while (fields)
 		{
-			printf("\e[32mField : \e[92m%s\e[0m\n", fields->value);
+			if (status == S_OK)
+				printf("\e[32mField : \e[92m%s\e[0m\n", fields->value);
 			next = fields->next;
 			free(fields);
 			fields = next;
 		}
+		if (status != S_OK)
+			return (1);
 		i++;
 	}
 }

--- a/src/test/wordhere.c
+++ b/src/test/wordhere.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 15:51:26 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/16 16:35:25 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 21:56:10 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <readline/readline.h>
 
+#include "status.h"
 #include "word.h"
 
 #define RLYELLOW "\001\e[33m\002"
@@ -45,14 +46,15 @@ static void	heredoc_loop(char *delimiter, bool quoted)
 			printf(GREEN "Found delimiter, exiting" RESETNL);
 			return ;
 		}
-		if (!quoted)
-			line = word_heredoc_line(line);
-		if (!line)
-			error_exit("Malloc failed in word_heredoc_line");
 		if (quoted)
 			printf(GREEN "Received line >" BRED "%s" GREEN "<" RESETNL, line);
-		else
+		else if (word_heredoc_line(&line) == S_OK)
 			printf(GREEN "Expanded line >" BRED "%s" GREEN "<" RESETNL, line);
+		else
+		{
+			free(line);
+			error_exit("Error in word_heredoc_line");
+		}
 		free(line);
 	}
 }

--- a/src/word/word_filename.c
+++ b/src/word/word_filename.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/11 15:48:35 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/19 19:36:26 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/12 19:09:13 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,51 +14,80 @@
 #include "word.h"
 
 #include <dirent.h>
+#include <errno.h>
 #include <stdbool.h>
 #include <stdlib.h>
 
 #include "libft.h"
 
-static void	word_filename_append(char *prefix, size_t prefix_len,
-				char *value, struct s_word_field ***append);
+#include "status.h"
+
+static t_status	word_filename_append(char *prefix, size_t prefix_len,
+					char *value, struct s_word_field ***append);
+static t_status	word_filename_scandir(DIR *dir, struct s_word_pattern *pattern,
+					struct s_word_field ***append, bool *had_matches);
+
+#define OPENDIR_ERRMSG "could not open current directory for filename matching"
+#define READDIR_ERRMSG "could not read directory for filename matching"
+
+/*
+	Linux closedir can only fail with invalid argument so we don't handle error.
+	POSIX also allows EINTR, but a) we should use SA_RESTART, and b) it likely
+	has same problem as error from close, where the file descriptor may be
+	closed already and retrying would be a mistake.
+*/
 
 /*
 	Match a pattern against files in the current directory and append matching
 	file names as fields to the given append pointer.
-
-	TODO: handle opendir error
-	TODO: handle readdir error
-	TODO: report closedir error
 */
-void	word_filename(char	*pattern_str, struct s_word_field ***matches_append,
-	bool *had_matches)
+t_status	word_filename(char *pattern_str,
+	struct s_word_field ***matches_append, bool *had_matches)
 {
 	struct s_word_pattern	pattern;
 	DIR						*dir;
-	struct dirent			*dirent;
+	t_status				status;
 
 	*had_matches = false;
 	if (!word_pattern_init_filename(&pattern, pattern_str))
-		return ;
+		return (S_OK);
 	dir = opendir(".");
-	dirent = readdir(dir);
-	while (dirent)
+	if (!dir)
+		return (status_err(S_RESET_ERR, OPENDIR_ERRMSG, NULL, errno));
+	status = word_filename_scandir(dir, &pattern, matches_append, had_matches);
+	closedir(dir);
+	return (status);
+}
+
+static t_status	word_filename_scandir(DIR *dir, struct s_word_pattern *pattern,
+	struct s_word_field ***matches_append, bool *had_matches)
+{
+	struct dirent	*dirent;
+	t_status		status;
+
+	while (true)
 	{
-		if (word_pattern_test_filename(&pattern, dirent->d_name))
+		errno = 0;
+		dirent = readdir(dir);
+		if (!dirent && errno)
+			return (status_err(S_RESET_ERR, READDIR_ERRMSG, NULL, errno));
+		if (!dirent)
+			return (S_OK);
+		if (word_pattern_test_filename(pattern, dirent->d_name))
 		{
-			word_filename_append(pattern.prefix, pattern.prefix_len,
-				dirent->d_name, matches_append);
+			status = word_filename_append(pattern->prefix, pattern->prefix_len,
+					dirent->d_name, matches_append);
+			if (status != S_OK)
+				return (status);
 			*had_matches = true;
 		}
-		dirent = readdir(dir);
 	}
-	closedir(dir);
 }
 
 /*
 	Allocate a new field for string and append it to the list.
 */
-static void	word_filename_append(char *prefix, size_t prefix_len,
+static t_status	word_filename_append(char *prefix, size_t prefix_len,
 	char *value, struct s_word_field ***append)
 {
 	size_t				value_size;
@@ -66,9 +95,12 @@ static void	word_filename_append(char *prefix, size_t prefix_len,
 
 	value_size = ft_strlen(value) + 1;
 	field = malloc(sizeof(*field) + prefix_len + value_size);
+	if (!field)
+		return (status_err(S_EXIT_ERR, ERRMSG_MALLOC, NULL, 0));
 	field->next = NULL;
 	ft_memcpy(field->value, prefix, prefix_len);
 	ft_memcpy(field->value + prefix_len, value, value_size);
 	**append = field;
 	*append = &field->next;
+	return (S_OK);
 }

--- a/src/word/word_internal.h
+++ b/src/word/word_internal.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/09 16:24:21 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/19 19:26:31 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/09 18:17:44 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,8 @@
 
 # include <stdbool.h>
 # include <stddef.h>
+
+# include "status.h"
 
 # define INTERNAL_ESCAPE '\001'
 
@@ -39,19 +41,21 @@ struct	s_word_pattern
 	size_t	prefix_len;
 };
 
-char	*word_exp_parse(char **word);
+char		*word_exp_parse(char **word);
 
-void	word_filename(char	*pattern, struct s_word_field ***matches_append,
-			bool *had_matches);
+t_status	word_filename(char *pattern, struct s_word_field ***matches_append,
+				bool *had_matches);
 
-void	word_out_char(struct s_word_state *state, char c, bool quoted);
-void	word_out_split(struct s_word_state *state);
+void		word_out_char(struct s_word_state *state, char c, bool quoted);
+t_status	word_out_split(struct s_word_state *state);
 
-bool	word_pattern_init_filename(struct s_word_pattern *pattern, char *str);
-bool	word_pattern_test_filename(struct s_word_pattern *pattern, char *str);
+bool		word_pattern_init_filename(
+				struct s_word_pattern *pattern, char *str);
+bool		word_pattern_test_filename(
+				struct s_word_pattern *pattern, char *str);
 
-void	word_scan(struct s_word_state *state);
+t_status	word_scan(struct s_word_state *state);
 
-void	word_unescape(char *escaped);
+void		word_unescape(char *escaped);
 
 #endif

--- a/src/word/word_scan.c
+++ b/src/word/word_scan.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/11 15:18:16 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/16 15:15:02 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/09 18:31:22 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,16 +14,17 @@
 
 #include <stdbool.h>
 
+#include "status.h"
 #include "util.h"
 
-static void	word_scan_expansion(struct s_word_state *state, bool quoted);
+static t_status	word_scan_expansion(struct s_word_state *state, bool quoted);
 
 /*
 	Scan the word for any special characters that need to be handled.
 	Recognizes quotes and maintains quote state, and recognizes expansions
 	introduced by `$`.
 */
-void	word_scan(struct s_word_state *state)
+t_status	word_scan(struct s_word_state *state)
 {
 	char	quote;
 	char	c;
@@ -43,7 +44,7 @@ void	word_scan(struct s_word_state *state)
 		if (quote)
 			state->out_has_quotes = true;
 	}
-	word_out_split(state);
+	return (word_out_split(state));
 }
 
 /*
@@ -53,23 +54,29 @@ void	word_scan(struct s_word_state *state)
 
 	TODO: split using IFS instead of isblank.
 */
-void	word_scan_expansion(struct s_word_state *state, bool quoted)
+t_status	word_scan_expansion(struct s_word_state *state, bool quoted)
 {
-	char	*value;
-	char	c;
+	char		*value;
+	char		c;
+	t_status	status;
 
 	value = word_exp_parse(&state->word);
 	if (!value)
 	{
 		word_out_char(state, '$', quoted);
-		return ;
+		return (S_OK);
 	}
 	while (*value)
 	{
 		c = *value++;
 		if (!quoted && util_isblank(c))
-			word_out_split(state);
+		{
+			status = word_out_split(state);
+			if (status != S_OK)
+				return (status);
+		}
 		else
 			word_out_char(state, c, quoted);
 	}
+	return (S_OK);
 }


### PR DESCRIPTION
* Status
  * Add newline at the end of messages
  * Define a message constant for `malloc` errors
  * Prepend `minishell: ` to output
  * Fix overflow guard
* Env
  * Use `S_EXIT_ERR` and the predefined message for `malloc`
  * Protect against null pointer in `environ`
  * While touching this module, also use libft `ft_strdup` and remove unused functions
* Parser
  * Switch to `t_status` for error handling
  * Print messages on `malloc` error
  * Make `parser_syntax_error` usable in return statements to simplify callers
    * Redirect: ensure the allocated node is attached to the tree so it doesn't need local freeing
* Word
  * Add error handling
  * Switch `word_heredoc_line` to `t_status` error handling