### PR TITLE
Execute error handling and builtin execution improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+         #
+#    By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/02/11 15:47:17 by amakinen          #+#    #+#              #
-#    Updated: 2025/05/18 06:16:04 by josmanov         ###   ########.fr        #
+#    Updated: 2025/06/03 18:25:17 by amakinen         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -41,6 +41,7 @@ SRCS := $(addprefix $(SRCDIR)/,\
 	parser/parser_redirect.c \
 	parser/parser_word.c \
 	parser/parser_heredoc.c \
+	execute/execute_redirect.c \
 	execute/simple_command.c \
 	execute/path.c \
 	execute/pipeline.c \

--- a/execute-notes.md
+++ b/execute-notes.md
@@ -1,0 +1,30 @@
+execute flow modes:
+- empty cmd
+	1. open redirs
+	2. close redirs
+- builtin
+	1. open redirs
+	2. exec builtin
+	3. close redirs
+- external, pipelined
+	1. open redirs
+	2. move redirs to stdin/stdout
+	3. pathsearch-execve
+- external, not pipelined
+	1. fork
+		1. open redirs
+		2. move redirs to stdin/stdout
+		3. pathsearch-execve
+		4. update exit_code and force exit
+	2. wait for child
+
+execute flow overall:
+1. expand args
+2. if external and not already child, fork
+3. if forked parent, wait for child and return
+4. open redirs
+5. if external, move redirs to stdin/stdout
+6. if external, pathsearch-execve
+7. if builtin, exec builtin
+8. if builtin or empty, close redirs
+9. if child, update exit_code and force exit

--- a/include/execute.h
+++ b/include/execute.h
@@ -6,12 +6,14 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:28:43 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/21 03:37:21 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/29 20:10:05 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef EXECUTE_H
 # define EXECUTE_H
+
+# include <stdbool.h>
 
 # include "env.h"
 # include "status.h"
@@ -21,7 +23,7 @@ struct	s_ast_list_entry;
 struct	s_ast_redirect;
 
 t_status	execute_simple_command(struct s_ast_simple_command *command,
-				t_env *env, int *exit_code);
+				t_env *env, int *exit_code, bool is_child);
 t_status	execute_pipeline(struct s_ast_simple_command *pipeline_head,
 				t_env *env, int *exit_code);
 t_status	execute_list(struct s_ast_list_entry *list_head,

--- a/include/execute.h
+++ b/include/execute.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   execute.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:28:43 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/10 22:23:48 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/05/21 03:37:21 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,17 +14,18 @@
 # define EXECUTE_H
 
 # include "env.h"
+# include "status.h"
 
 struct	s_ast_simple_command;
 struct	s_ast_list_entry;
 struct	s_ast_redirect;
 
-void	execute_simple_command(struct s_ast_simple_command *command,
-			t_env *env);
-int		execute_pipeline(struct s_ast_simple_command *pipeline_head,
-			t_env *env);
-int		execute_list(struct s_ast_list_entry *list_head,
-			t_env *env);
-int		process_heredoc(struct s_ast_redirect *redirect);
+t_status	execute_simple_command(struct s_ast_simple_command *command,
+				t_env *env, int *exit_code);
+t_status	execute_pipeline(struct s_ast_simple_command *pipeline_head,
+				t_env *env, int *exit_code);
+t_status	execute_list(struct s_ast_list_entry *list_head,
+				t_env *env, int *exit_code);
+int			process_heredoc(struct s_ast_redirect *redirect);
 
 #endif

--- a/src/execute/execute_internal.h
+++ b/src/execute/execute_internal.h
@@ -3,25 +3,29 @@
 /*                                                        :::      ::::::::   */
 /*   execute_internal.h                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:27:27 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/12 17:38:26 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/05/29 19:19:38 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef EXECUTE_INTERNAL_H
 # define EXECUTE_INTERNAL_H
 
+# include <stdbool.h>
+
+# include "ast.h"
 # include "env.h"
+# include "status.h"
 
 /*
 	Internal functions for command execution
 	These functions handle the finding and executing external commands
 */
-void	handle_absolute_path(char **argv, t_env *env, int *exit_code);
+void		handle_absolute_path(char **argv, t_env *env, int *exit_code);
 
-void	handle_path_search(char **argv, t_env *env, int *exit_code);
+void		handle_path_search(char **argv, t_env *env, int *exit_code);
 
 struct	s_pipeline_fds
 {
@@ -31,5 +35,17 @@ struct	s_pipeline_fds
 };
 
 # define NO_PIPE -1
+
+struct s_redir_fds
+{
+	int	in;
+	int	out;
+};
+
+# define NO_REDIR -1
+
+t_status	execute_redirect_prepare(struct s_redir_fds *fds,
+				struct s_ast_redirect *redirs);
+t_status	execute_redirect_finish(struct s_redir_fds *fds, bool apply);
 
 #endif

--- a/src/execute/execute_redirect.c
+++ b/src/execute/execute_redirect.c
@@ -1,0 +1,154 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   execute_redirect.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/28 17:47:16 by amakinen          #+#    #+#             */
+/*   Updated: 2025/05/29 19:19:38 by amakinen         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "execute.h"
+#include "execute_internal.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <unistd.h>
+
+#include "ast.h"
+#include "status.h"
+#include "word.h"
+
+/*
+	TODO (entire file): Does close error need handling? Store path with fds for
+	close error?
+*/
+
+/*
+	Prepare heredoc for redirection and store the file descriptor in the correct
+	fds field. If the field holds another file descriptor, close it first.
+
+	No error message printed here, because process_heredoc prints its own.
+	TODO: Refactor heredoc handling to skip this wrapper.
+*/
+static t_status	execute_redirect_heredoc(struct s_ast_redirect *redir,
+	struct s_redir_fds *fds)
+{
+	if (fds->in != NO_REDIR)
+		close(fds->in);
+	fds->in = process_heredoc(redir);
+	if (fds->in == -1)
+		return (S_COMM_ERR);
+	return (S_OK);
+}
+
+/*
+	Open a path for redirection and store the file descriptor in the correct
+	fds field. If the field holds another file descriptor, close it first.
+*/
+static t_status	execute_redirect_open(enum e_ast_redirect_op op,
+	const char *path, struct s_redir_fds *fds)
+{
+	if (op == AST_REDIR_IN && fds->in != NO_REDIR)
+		close(fds->in);
+	else if (op != AST_REDIR_IN && fds->out != NO_REDIR)
+		close(fds->out);
+	if (op == AST_REDIR_IN)
+		fds->in = open(path, O_RDONLY);
+	else if (op == AST_REDIR_OUT)
+		fds->out = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0666);
+	else if (op == AST_REDIR_APP)
+		fds->out = open(path, O_CREAT | O_WRONLY | O_APPEND, 0666);
+	if ((op == AST_REDIR_IN && fds->in == -1)
+		|| (op != AST_REDIR_IN && fds->out == -1))
+		return (status_err(S_COMM_ERR, "failed to open redirection",
+				path, errno));
+	return (S_OK);
+}
+
+/*
+	Expand the word of a file redirection and open it as a path. If expansion
+	doesn't generate exactly one field, an error is reported instead.
+*/
+static t_status	execute_redirect_file(struct s_ast_redirect *redir,
+	struct s_redir_fds *fds)
+{
+	t_status			status;
+	struct s_word_field	*expanded;
+	struct s_word_field	**exp_append;
+
+	expanded = NULL;
+	exp_append = &expanded;
+	status = word_expand(redir->word, &exp_append);
+	if (status == S_OK && expanded && !expanded->next)
+		status = execute_redirect_open(redir->op, expanded->value, fds);
+	else if (status == S_OK)
+		status = status_err(S_COMM_ERR, "ambiguous redirect", redir->word, 0);
+	word_free(expanded);
+	return (status);
+}
+
+/*
+	Finish working with redirection file descriptors. If apply is set, move the
+	file descriptors to the correct FD numbers (before executing an external
+	command). Otherwise, close the file descriptors (after an error, or after
+	executing a builtin or an empty command).
+*/
+t_status	execute_redirect_finish(struct s_redir_fds *fds, bool apply)
+{
+	t_status	status;
+
+	status = S_OK;
+	if (fds->in != NO_REDIR)
+	{
+		if (apply && dup2(fds->in, STDIN_FILENO) < 0)
+			status = status_err(S_EXIT_ERR, "execute_redirect_apply",
+					"dup2() failed", errno);
+		close(fds->in);
+	}
+	if (fds->out != NO_REDIR)
+	{
+		if (apply && dup2(fds->out, STDOUT_FILENO) < 0)
+			status = status_err(S_EXIT_ERR, "execute_redirect_apply",
+					"dup2() failed", errno);
+		close(fds->out);
+	}
+	return (status);
+}
+
+/*
+	Process all redirection AST nodes in a list, storing the final redirection
+	file descriptors in the fds struct.
+
+	If an error happens, file descriptors are closed and values in fds are
+	undefined.
+*/
+t_status	execute_redirect_prepare(struct s_redir_fds *fds,
+	struct s_ast_redirect *redirs)
+{
+	t_status				status;
+	enum e_ast_redirect_op	op;
+
+	fds->in = NO_REDIR;
+	fds->out = NO_REDIR;
+	status = S_OK;
+	while (redirs && status == S_OK)
+	{
+		op = redirs->op;
+		if (op == AST_REDIR_IN || op == AST_REDIR_OUT || op == AST_REDIR_APP)
+			status = execute_redirect_file(redirs, fds);
+		else if (op == AST_HEREDOC)
+			status = execute_redirect_heredoc(redirs, fds);
+		else
+			status = status_err(S_EXIT_ERR, "execute_redirect: internal error",
+					"invalid ast_redirect type", 0);
+		redirs = redirs->next;
+	}
+	if (status != S_OK)
+		execute_redirect_finish(fds, false);
+	return (status);
+}

--- a/src/execute/pipeline.c
+++ b/src/execute/pipeline.c
@@ -6,13 +6,14 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/24 17:13:08 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/21 03:54:04 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/29 21:36:25 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "execute_internal.h"
 #include "execute.h"
 
+#include <errno.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -25,75 +26,121 @@
 
 /*
 	Create a pipe if necessary and determine input/output FDs for the current
-	command.
-	TODO: handle pipe() error
+	command, then fork a child process and store the result in fork_result.
 */
-static void	pipeline_create_pipe(struct s_pipeline_fds *fds,
-	bool first, bool last)
+static t_status	execute_pipeline_create_pipe_and_fork(
+	struct s_pipeline_fds *fds, bool first, bool last, pid_t *fork_result)
 {
 	int	pipe_fd[2];
 
-	if (first)
-		fds->in = NO_PIPE;
-	else
+	fds->in = NO_PIPE;
+	if (!first)
 		fds->in = fds->next_in;
-	if (last)
+	fds->next_in = NO_PIPE;
+	fds->out = NO_PIPE;
+	if (!last)
 	{
-		fds->next_in = NO_PIPE;
-		fds->out = NO_PIPE;
-	}
-	else
-	{
-		pipe(pipe_fd);
+		if (pipe(pipe_fd) < 0)
+			return (status_err(S_RESET_ERR, "execute_pipeline",
+					"pipe() failed", errno));
 		fds->next_in = pipe_fd[0];
 		fds->out = pipe_fd[1];
 	}
+	*fork_result = fork();
+	if (*fork_result < 0)
+		return (status_err(S_RESET_ERR, "execute_pipeline",
+				"fork() failed", errno));
+	return (S_OK);
 }
 
 /*
-	Move the input and output pipes to correct FD numbers, and close the read
-	end of the pipe as it belongs to the next command and not this one.
-	TODO: handle dup2() error
-	TODO: report close() error
+	Move the input and output pipes to correct FD numbers, close the read end of
+	the output pipe, and execute the command. Set the status to exit from the
+	child process if the command didn't execve.
+
+	We don't need to check for close() errors here. They are only useful for
+	reporting potential data loss in case of a delayed write error, or reporting
+	that a delayed write may still be pending in case of EINTR. Such delayed
+	writes that are flushed on close don't apply to pipes, and we haven't
+	written anything yet anyway.
 */
-static void	pipeline_cleanup_child(struct s_pipeline_fds *fds)
+static t_status	execute_pipeline_child(struct s_pipeline_fds *fds,
+	struct s_ast_simple_command *child_command, t_env *env, int *exit_code)
 {
+	t_status	status;
+
+	status = S_OK;
 	if (fds->in != NO_PIPE)
 	{
-		dup2(fds->in, STDIN_FILENO);
+		if (dup2(fds->in, STDIN_FILENO) < 0)
+			status = status_err(S_EXIT_ERR, "execute_pipeline_child",
+					"dup2() failed", errno);
 		close(fds->in);
 	}
 	if (fds->next_in != NO_PIPE)
 		close(fds->next_in);
 	if (fds->out != NO_PIPE)
 	{
-		dup2(fds->out, STDOUT_FILENO);
+		if (dup2(fds->out, STDOUT_FILENO) < 0)
+			status = status_err(S_EXIT_ERR, "execute_pipeline_child",
+					"dup2() failed", errno);
 		close(fds->out);
 	}
+	if (status == S_OK)
+		status = execute_simple_command(child_command, env, exit_code);
+	return (status_force_exit(status, exit_code));
 }
 
 /*
 	Close the pipe FDs created for the current command and not needed for the
-	next one.
-	TODO: report close() error
+	next one. Also close read end of the next pipe if fork failed and we're not
+	continuing to next command.
+
+	We don't need to check for close() errors here. They are only useful for
+	reporting potential data loss in case of a delayed write error, or reporting
+	that a delayed write may still be pending in case of EINTR. Such delayed
+	writes that are flushed on close don't apply to pipes, and we haven't
+	written anything yet anyway.
 */
-static void	pipeline_cleanup_parent(struct s_pipeline_fds *fds)
+static void	execute_pipeline_cleanup(struct s_pipeline_fds *fds, bool had_error)
 {
 	if (fds->in != NO_PIPE)
 		close(fds->in);
+	if (had_error && fds->next_in != NO_PIPE)
+		close(fds->next_in);
 	if (fds->out != NO_PIPE)
 		close(fds->out);
 }
 
-static t_status	pipeline_wait_for_children(int num_children, pid_t last_child,
-	int	*exit_code)
+/*
+	Wait until all child processes have exited. Store the exit status of the
+	last process of the pipeline. Pass through the given t_status unless an
+	unexpected error happens.
+
+	If fork fails, last_child is -1 and exit_code remains unmodified, but in an
+	error case the returned status should override exit_code anyway.
+
+	When there are no more child processes, wait fails with ECHILD. The actual
+	error case should be impossible to hit, but no harm in checking.
+*/
+static t_status	execute_pipeline_wait_for_children(
+	t_status status, pid_t last_child, int *exit_code)
 {
 	int		wait_status;
 	pid_t	waited_child;
 
-	while (num_children--)
+	while (true)
 	{
 		waited_child = wait(&wait_status);
+		if (waited_child < 0)
+		{
+			if (errno == EINTR)
+				continue ;
+			if (errno == ECHILD)
+				return (status);
+			return (status_err(S_EXIT_ERR, "execute_pipeline: internal error",
+					"wait failed", errno));
+		}
 		if (waited_child == last_child)
 		{
 			if (WIFEXITED(wait_status))
@@ -102,41 +149,36 @@ static t_status	pipeline_wait_for_children(int num_children, pid_t last_child,
 				*exit_code = 128 + WTERMSIG(wait_status);
 		}
 	}
-	return (S_OK);
 }
 
 /*
 	Execute all commands in a pipeline in parallel, connecting the stdout of
 	each command to the stdin of the next one.
-	TODO: handle fork() error
 	TODO: handle single builtin in main process
 */
 t_status	execute_pipeline(struct s_ast_simple_command *pipeline_head,
 	t_env *env, int *exit_code)
 {
+	t_status				status;
 	pid_t					child;
 	bool					first;
 	struct s_pipeline_fds	fds;
-	int						num_children;
 
+	status = S_OK;
 	first = true;
-	num_children = 0;
 	child = 0;
 	while (pipeline_head)
 	{
-		num_children++;
-		pipeline_create_pipe(&fds, first, !pipeline_head->next);
-		child = fork();
-		if (child == 0)
-		{
-			pipeline_cleanup_child(&fds);
-			execute_simple_command(pipeline_head, env, exit_code);
-			return (S_EXIT_OK);
-		}
-		else
-			pipeline_cleanup_parent(&fds);
+		status = execute_pipeline_create_pipe_and_fork(
+				&fds, first, !pipeline_head->next, &child);
+		if (status == S_OK && child == 0)
+			return (execute_pipeline_child(&fds, pipeline_head, env,
+					exit_code));
+		execute_pipeline_cleanup(&fds, status != S_OK);
+		if (status != S_OK)
+			break ;
 		pipeline_head = pipeline_head->next;
 		first = false;
 	}
-	return (pipeline_wait_for_children(num_children, child, exit_code));
+	return (execute_pipeline_wait_for_children(status, child, exit_code));
 }

--- a/src/execute/simple_command.c
+++ b/src/execute/simple_command.c
@@ -6,15 +6,19 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:21:06 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/29 19:19:57 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/29 20:09:55 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "execute.h"
 #include "execute_internal.h"
 
+#include <errno.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include "ast.h"
 #include "builtin.h"
@@ -89,32 +93,97 @@ static t_status	execute_expand_args(struct s_ast_command_word *args,
 }
 
 /*
-	Executes a simple command from the AST
-	Handles redirections, builds argument array, and executes the command
-	Exits with appropriate status code based on command execution result
-	TODO: handle builtins
+	Fork a child process for executing an external command. Child process
+	sets is_child and returns, while main process waits for child to exit and
+	stores its exit status in exit_code.
+*/
+static t_status	execute_command_fork(bool *is_child, int *exit_code)
+{
+	pid_t	child_pid;
+	int		wait_status;
+
+	child_pid = fork();
+	if (child_pid < 0)
+		return (status_err(S_RESET_ERR, "execute_command",
+				"fork() failed", errno));
+	if (child_pid == 0)
+	{
+		*is_child = true;
+		return (S_OK);
+	}
+	while (wait(&wait_status) < 0)
+	{
+		if (errno == EINTR)
+			continue ;
+		return (status_err(S_EXIT_ERR, "execute_command: internal error",
+				"wait() failed", errno));
+	}
+	if (WIFEXITED(wait_status))
+		*exit_code = WEXITSTATUS(wait_status);
+	else if (WIFSIGNALED(wait_status))
+		*exit_code = 128 + WTERMSIG(wait_status);
+	return (S_OK);
+}
+
+/*
+	Apply redirections and execute the command according to its type. External
+	commands move redirections to their correct file descriptor numbers, while
+	builtins and empty commands use the the temporary file descriptors directly
+	and close them afterwards.
+*/
+static t_status	execute_command_execute(struct s_ast_redirect *redirs,
+	char **argv, t_env *env, int *exit_code)
+{
+	t_status			status;
+	struct s_redir_fds	fds;
+	t_builtin_func		*builtin;
+	bool				is_external;
+
+	status = execute_redirect_prepare(&fds, redirs);
+	if (status != S_OK)
+		return (status);
+	builtin = NULL;
+	if (argv)
+		builtin = builtin_get_func(argv[0]);
+	is_external = argv && !builtin;
+	if (is_external)
+		status = execute_redirect_finish(&fds, true);
+	if (is_external && status == S_OK)
+		handle_path_search(argv, env, exit_code);
+	if (builtin && fds.out == NO_REDIR)
+		status = builtin(argv, env, exit_code, STDOUT_FILENO);
+	else if (builtin)
+		status = builtin(argv, env, exit_code, fds.out);
+	if (!is_external)
+		execute_redirect_finish(&fds, false);
+	return (status);
+}
+
+/*
+	Execute a simple command from the AST
+
+	Expands arguments, builds argv array and forks a child process if necessary.
+	If forked, parent waits for child and collects its exit code. If not forked
+	or in child, applies redirections and executes the command. Forces the child
+	process to exit instead of staying around as a duplicate shell instance.
 */
 t_status	execute_simple_command(struct s_ast_simple_command *command,
-	t_env *env, int *exit_code)
+	t_env *env, int *exit_code, bool is_child)
 {
 	t_status			status;
 	struct s_word_field	*arg_fields;
 	char				**argv;
-	t_builtin_func		*builtin;
-	struct s_redir_fds	fds;
+	bool				need_child;
 
-	status = execute_redirect_prepare(&fds, command->redirs);
+	status = execute_expand_args(command->args, &arg_fields, &argv);
 	if (status == S_OK)
-		status = execute_redirect_finish(&fds, true);
-	if (status == S_OK)
-		status = execute_expand_args(command->args, &arg_fields, &argv);
-	if (status != S_OK || !argv)
-		return (status);
-	builtin = builtin_get_func(argv[0]);
-	if (builtin)
-		status = builtin(argv, env, exit_code, 1);
-	else
-		handle_path_search(argv, env, exit_code);
+		need_child = argv && !builtin_get_func(argv[0]);
+	if (status == S_OK && need_child && !is_child)
+		status = execute_command_fork(&is_child, exit_code);
+	if (status == S_OK && (!need_child || is_child))
+		status = execute_command_execute(command->redirs, argv, env, exit_code);
+	if (is_child)
+		status = status_force_exit(status, exit_code);
 	free(argv);
 	word_free(arg_fields);
 	return (status);

--- a/src/execute/simple_command.c
+++ b/src/execute/simple_command.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:21:06 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/21 03:42:29 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/26 21:16:05 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,7 @@
 #include "builtin.h"
 #include "env.h"
 #include "status.h"
+#include "word.h"
 
 int	process_heredoc(struct s_ast_redirect *redirect);
 
@@ -74,15 +75,15 @@ static void	apply_redirects(struct s_ast_redirect *redirs)
 }
 
 /*
-	Converts the AST command word list to an argv array for execve
-	Allocates a new array with command and arguments, NULL-terminated
-	TODO: apply word processing steps
+	Count args in the given field list, allocate an argv-style NULL-terminated
+	pointer array, and fill it with pointers to field values.
 */
-static char	**build_argv(struct s_ast_command_word *args)
+static t_status	execute_arg_fields_to_argv(
+	struct s_word_field *args, char ***argv_out)
 {
-	size_t						n_args;
-	char						**argv;
-	struct s_ast_command_word	*current_arg;
+	size_t				n_args;
+	char				**argv;
+	struct s_word_field	*current_arg;
 
 	n_args = 0;
 	current_arg = args;
@@ -92,18 +93,51 @@ static char	**build_argv(struct s_ast_command_word *args)
 		current_arg = current_arg->next;
 	}
 	argv = malloc((n_args + 1) * sizeof(*argv));
+	*argv_out = argv;
 	if (!argv)
-		return (NULL);
+		return (status_err(S_EXIT_ERR, ERRMSG_MALLOC, NULL, 0));
 	n_args = 0;
 	current_arg = args;
 	while (current_arg)
 	{
-		argv[n_args] = current_arg->word;
+		argv[n_args] = current_arg->value;
 		n_args++;
 		current_arg = current_arg->next;
 	}
 	argv[n_args] = NULL;
-	return (argv);
+	return (S_OK);
+}
+
+/*
+	Expand all words in AST command word list into a field list, and build an
+	argv array of field values that can be passed to execve.
+
+	The argv array entries point to strings owned by the fields list, so the
+	field list must not be freed while the argv array is in use. The caller
+	is responsible for freeing the fields list, even in case of failure.
+
+	If expansion produces no fields, no memory is allocated and the out pointers
+	are set to null pointers.
+*/
+static t_status	execute_expand_args(struct s_ast_command_word *args,
+	struct s_word_field **fields_out, char ***argv_out)
+{
+	t_status			status;
+	struct s_word_field	**fields_append;
+
+	*fields_out = NULL;
+	*argv_out = NULL;
+	fields_append = fields_out;
+	while (args)
+	{
+		status = word_expand(args->word, &fields_append);
+		if (status != S_OK)
+			return (status);
+		args = args->next;
+	}
+	if (!*fields_out)
+		return (S_OK);
+	return (execute_arg_fields_to_argv(*fields_out, argv_out));
 }
 
 /*
@@ -115,22 +149,21 @@ static char	**build_argv(struct s_ast_command_word *args)
 t_status	execute_simple_command(struct s_ast_simple_command *command,
 	t_env *env, int *exit_code)
 {
-	t_status		status;
-	char			**argv;
-	t_builtin_func	*builtin;
+	t_status			status;
+	struct s_word_field	*arg_fields;
+	char				**argv;
+	t_builtin_func		*builtin;
 
 	apply_redirects(command->redirs);
-	if (!command->args)
-		return (S_OK);
-	argv = build_argv(command->args);
-	if (!argv)
-		return (S_EXIT_ERR);
+	status = execute_expand_args(command->args, &arg_fields, &argv);
+	if (status != S_OK || !argv)
+		return (status);
 	builtin = builtin_get_func(argv[0]);
-	status = S_OK;
 	if (builtin)
 		status = builtin(argv, env, exit_code, 1);
 	else
 		handle_path_search(argv, env, exit_code);
 	free(argv);
+	word_free(arg_fields);
 	return (status);
 }

--- a/src/execute/simple_command.c
+++ b/src/execute/simple_command.c
@@ -6,73 +6,21 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:21:06 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/26 21:16:05 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/29 19:19:57 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "execute.h"
 #include "execute_internal.h"
 
-#include <fcntl.h>
-#include <stdio.h>
+#include <stdbool.h>
 #include <stdlib.h>
-#include <unistd.h>
 
 #include "ast.h"
 #include "builtin.h"
 #include "env.h"
 #include "status.h"
 #include "word.h"
-
-int	process_heredoc(struct s_ast_redirect *redirect);
-
-/*
-	Performs a file redirection by opening a file and duplicating descriptors
-	Handles different types of redirections based on the open_flags parameter
-	TODO: handle open() error
-	TODO: handle dup2() error
-	TODO: report close() error
-*/
-static void	do_redirect(const char *path, int target_fd, int open_flags)
-{
-	int	new_fd;
-
-	new_fd = open(path, open_flags, 0666);
-	dup2(new_fd, target_fd);
-	close(new_fd);
-}
-
-/*
-	Processes and applies all redirections from the AST redirection list
-	Supports input (<), output (>), and append (>>) redirections
-	TODO: apply word processing steps
-*/
-static void	apply_redirects(struct s_ast_redirect *redirs)
-{
-	int	fd;
-
-	while (redirs)
-	{
-		if (redirs->op == AST_REDIR_IN)
-			do_redirect(redirs->word, STDIN_FILENO, O_RDONLY);
-		else if (redirs->op == AST_REDIR_OUT)
-			do_redirect(redirs->word, STDOUT_FILENO,
-				O_CREAT | O_WRONLY | O_TRUNC);
-		else if (redirs->op == AST_REDIR_APP)
-			do_redirect(redirs->word, STDOUT_FILENO,
-				O_CREAT | O_WRONLY | O_APPEND);
-		else if (redirs->op == AST_HEREDOC)
-		{
-			fd = process_heredoc(redirs);
-			if (fd != -1)
-			{
-				dup2(fd, STDIN_FILENO);
-				close(fd);
-			}
-		}
-		redirs = redirs->next;
-	}
-}
 
 /*
 	Count args in the given field list, allocate an argv-style NULL-terminated
@@ -153,9 +101,13 @@ t_status	execute_simple_command(struct s_ast_simple_command *command,
 	struct s_word_field	*arg_fields;
 	char				**argv;
 	t_builtin_func		*builtin;
+	struct s_redir_fds	fds;
 
-	apply_redirects(command->redirs);
-	status = execute_expand_args(command->args, &arg_fields, &argv);
+	status = execute_redirect_prepare(&fds, command->redirs);
+	if (status == S_OK)
+		status = execute_redirect_finish(&fds, true);
+	if (status == S_OK)
+		status = execute_expand_args(command->args, &arg_fields, &argv);
 	if (status != S_OK || !argv)
 		return (status);
 	builtin = builtin_get_func(argv[0]);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/11 15:55:33 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/29 21:20:54 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/29 21:22:04 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,7 @@ static t_status	minishell_do_line(t_env *env, int *exit_code)
 		add_history(line);
 	free(line);
 	if (status == S_OK)
-		*exit_code = execute_list(ast, env);
+		status = execute_list(ast, env, exit_code);
 	free_ast(ast);
 	status_set_exit_code(status, exit_code);
 	return (status);

--- a/src/test/list.c
+++ b/src/test/list.c
@@ -3,19 +3,19 @@
 /*                                                        :::      ::::::::   */
 /*   list.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 23:14:19 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/01 22:18:51 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/05/21 04:13:10 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include <unistd.h>
 #include <stdio.h>
+#include <unistd.h>
 
 #include "ast.h"
-#include "execute.h"
 #include "env.h"
+#include "execute.h"
 #include "status.h"
 
 /*
@@ -68,13 +68,16 @@ struct s_ast_list_entry	*g_test_list
 int	main(void)
 {
 	t_env		env;
-	t_status	env_status;
-	int			status;
+	t_status	status;
+	int			exit_code;
 
-	env_status = env_init(&env);
-	if (env_status != S_OK)
+	status = env_init(&env);
+	if (status != S_OK)
 		return (1);
-	status = execute_list(g_test_list, &env);
-	dprintf(STDERR_FILENO, "execute_list returned status: %d\n", status);
+	exit_code = -1;
+	status = execute_list(g_test_list, &env, &exit_code);
+	dprintf(STDERR_FILENO,
+		"execute_list returned internal status %d, exit code %d\n",
+		status, exit_code);
 	env_free(&env);
 }

--- a/src/test/pipeline.c
+++ b/src/test/pipeline.c
@@ -3,18 +3,19 @@
 /*                                                        :::      ::::::::   */
 /*   pipeline.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 18:35:02 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/01 22:18:34 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/05/21 04:13:20 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdio.h>
 #include <unistd.h>
 
 #include "ast.h"
-#include "execute.h"
 #include "env.h"
+#include "execute.h"
 #include "status.h"
 
 /*
@@ -88,11 +89,16 @@ int	main(void)
 {
 	t_env		env;
 	t_status	status;
+	int			exit_code;
 
 	status = env_init(&env);
 	if (status != S_OK)
 		return (1);
-	execute_pipeline(g_test_pipeline, &env);
-	write(STDERR_FILENO, "execute_pipeline returned\n", 26);
+	exit_code = -1;
+	status = execute_pipeline(g_test_pipeline, &env, &exit_code);
+	dprintf(STDERR_FILENO,
+		"execute_pipeline returned internal status %d, exit code %d\n",
+		status, exit_code);
 	env_free(&env);
+	return (exit_code);
 }

--- a/src/test/simple_command.c
+++ b/src/test/simple_command.c
@@ -6,10 +6,11 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 18:11:56 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/21 04:12:47 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/05/29 19:32:36 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <unistd.h>
 
@@ -52,7 +53,7 @@ int	main(void)
 	if (status != S_OK)
 		return (1);
 	exit_code = -1;
-	status = execute_simple_command(g_test_command, &env, &exit_code);
+	status = execute_simple_command(g_test_command, &env, &exit_code, false);
 	dprintf(STDERR_FILENO,
 		"execute_simple_command returned internal status %d, exit code %d\n",
 		status, exit_code);

--- a/src/test/simple_command.c
+++ b/src/test/simple_command.c
@@ -3,18 +3,19 @@
 /*                                                        :::      ::::::::   */
 /*   simple_command.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 18:11:56 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/01 22:18:16 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/05/21 04:12:47 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdio.h>
 #include <unistd.h>
 
 #include "ast.h"
-#include "execute.h"
 #include "env.h"
+#include "execute.h"
 #include "status.h"
 
 /*
@@ -45,11 +46,16 @@ int	main(void)
 {
 	t_env		env;
 	t_status	status;
+	int			exit_code;
 
 	status = env_init(&env);
 	if (status != S_OK)
 		return (1);
-	execute_simple_command(g_test_command, &env);
-	write(STDERR_FILENO, "execute_simple_command returned\n", 32);
+	exit_code = -1;
+	status = execute_simple_command(g_test_command, &env, &exit_code);
+	dprintf(STDERR_FILENO,
+		"execute_simple_command returned internal status %d, exit code %d\n",
+		status, exit_code);
 	env_free(&env);
+	return (exit_code);
 }


### PR DESCRIPTION
Switch return types to `t_status` and update/use `exit_code`.
Handle errors properly.
Handle word expansions for arguments.
Handle word expansions for redirections.
Run non-pipelined builtins without forking.

Closes #20. Contributes to #22.

~**DO NOT MERGE YET** - this work builds upon on #40 and #41, so to facilitate reviewing, this PR is targeting a temporary branch with those branches merged to it. Rebase this branch on main once the dependencies are merged.~