### PR TITLE
Expansion improvements and related refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/02/11 15:47:17 by amakinen          #+#    #+#              #
-#    Updated: 2025/06/03 18:25:17 by amakinen         ###   ########.fr        #
+#    Updated: 2025/06/04 20:10:15 by amakinen         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -58,9 +58,9 @@ SRCS := $(addprefix $(SRCDIR)/,\
 	word/word_pattern.c \
 	word/word_scan.c \
 	word/word_unescape.c \
-	env/init.c \
-	env/get_set.c \
-	env/utils.c \
+	shenv/init.c \
+	shenv/get_set.c \
+	shenv/utils.c \
 )
 
 OBJS := $(SRCS:$(SRCDIR)/%.c=$(OBJDIR)/%.o)

--- a/include/ast.h
+++ b/include/ast.h
@@ -3,15 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   ast.h                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/19 12:07:51 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/10 22:23:45 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 22:56:36 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef AST_H
 # define AST_H
+
+# include <stdbool.h>
 
 /*
 AST for the following grammar:
@@ -52,6 +54,7 @@ struct s_ast_redirect
 {
 	enum e_ast_redirect_op		op;
 	char						*word;
+	bool						heredoc_quoted;
 	struct s_ast_command_word	*heredoc_lines;
 	struct s_ast_redirect		*next;
 };

--- a/include/builtin.h
+++ b/include/builtin.h
@@ -6,17 +6,17 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/12 15:12:18 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/12 15:18:33 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef BUILTIN_H
 # define BUILTIN_H
 
-# include "env.h"
+# include "shenv.h"
 # include "status.h"
 
-typedef t_status	t_builtin_func(char	**argv, t_env *env,
+typedef t_status	t_builtin_func(char	**argv, t_shenv *env,
 						int *exit_code, int stdout_fd);
 
 t_builtin_func	*builtin_get_func(const char *name);

--- a/include/builtin.h
+++ b/include/builtin.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/12 15:12:18 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:38:14 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,8 +16,7 @@
 # include "shenv.h"
 # include "status.h"
 
-typedef t_status	t_builtin_func(char	**argv, t_shenv *env,
-						int *exit_code, int stdout_fd);
+typedef t_status	t_builtin_func(char	**argv, t_shenv *env, int stdout_fd);
 
 t_builtin_func	*builtin_get_func(const char *name);
 

--- a/include/execute.h
+++ b/include/execute.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:28:43 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:37:54 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,11 +23,11 @@ struct	s_ast_list_entry;
 struct	s_ast_redirect;
 
 t_status	execute_simple_command(struct s_ast_simple_command *command,
-				t_shenv *env, int *exit_code, bool is_child);
+				t_shenv *env, bool is_child);
 t_status	execute_pipeline(struct s_ast_simple_command *pipeline_head,
-				t_shenv *env, int *exit_code);
+				t_shenv *env);
 t_status	execute_list(struct s_ast_list_entry *list_head,
-				t_shenv *env, int *exit_code);
+				t_shenv *env);
 int			process_heredoc(struct s_ast_redirect *redirect);
 
 #endif

--- a/include/execute.h
+++ b/include/execute.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:28:43 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/29 20:10:05 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
 
 # include <stdbool.h>
 
-# include "env.h"
+# include "shenv.h"
 # include "status.h"
 
 struct	s_ast_simple_command;
@@ -23,11 +23,11 @@ struct	s_ast_list_entry;
 struct	s_ast_redirect;
 
 t_status	execute_simple_command(struct s_ast_simple_command *command,
-				t_env *env, int *exit_code, bool is_child);
+				t_shenv *env, int *exit_code, bool is_child);
 t_status	execute_pipeline(struct s_ast_simple_command *pipeline_head,
-				t_env *env, int *exit_code);
+				t_shenv *env, int *exit_code);
 t_status	execute_list(struct s_ast_list_entry *list_head,
-				t_env *env, int *exit_code);
+				t_shenv *env, int *exit_code);
 int			process_heredoc(struct s_ast_redirect *redirect);
 
 #endif

--- a/include/execute.h
+++ b/include/execute.h
@@ -6,28 +6,18 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:28:43 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 20:37:54 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 22:17:10 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef EXECUTE_H
 # define EXECUTE_H
 
-# include <stdbool.h>
-
+# include "ast.h"
 # include "shenv.h"
 # include "status.h"
 
-struct	s_ast_simple_command;
-struct	s_ast_list_entry;
-struct	s_ast_redirect;
-
-t_status	execute_simple_command(struct s_ast_simple_command *command,
-				t_shenv *env, bool is_child);
-t_status	execute_pipeline(struct s_ast_simple_command *pipeline_head,
-				t_shenv *env);
 t_status	execute_list(struct s_ast_list_entry *list_head,
 				t_shenv *env);
-int			process_heredoc(struct s_ast_redirect *redirect);
 
 #endif

--- a/include/shenv.h
+++ b/include/shenv.h
@@ -1,43 +1,43 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   env.h                                              :+:      :+:    :+:   */
+/*   shenv.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 13:24:48 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 19:09:18 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:58 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef ENV_H
-# define ENV_H
+#ifndef SHENV_H
+# define SHENV_H
 
 # include <stddef.h>
 
 # include "status.h"
 
 /* Environment structure */
-typedef struct s_env
+typedef struct s_shenv
 {
-	char	**env_array;
-	size_t	array_size;
-	size_t	used_size;
-}	t_env;
+	char	**var_array;
+	size_t	var_array_size;
+	size_t	var_array_used;
+}	t_shenv;
 
 /* Initialize environment from extern environ */
-t_status	env_init(t_env *env);
+t_status	shenv_init(t_shenv *env);
 
 /* Free all allocated environment memory */
-void		env_free(t_env *env);
+void		shenv_free(t_shenv *env);
 
 /* Get environment variable value */
-char		*env_get(t_env *env, const char *key);
+char		*shenv_var_get(t_shenv *env, const char *key);
 
 /* Set environment variable */
-t_status	env_set(t_env *env, const char *key, const char *value);
+t_status	shenv_var_set(t_shenv *env, const char *key, const char *value);
 
 /* Unset environment variable */
-t_status	env_unset(t_env *env, const char *key);
+t_status	shenv_var_unset(t_shenv *env, const char *key);
 
 #endif

--- a/include/shenv.h
+++ b/include/shenv.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 13:24:48 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:58 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:38:00 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,7 @@ typedef struct s_shenv
 	char	**var_array;
 	size_t	var_array_size;
 	size_t	var_array_used;
+	int		exit_code;
 }	t_shenv;
 
 /* Initialize environment from extern environ */

--- a/include/status.h
+++ b/include/status.h
@@ -3,15 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   status.h                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 21:50:28 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/03 14:57:24 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:41:05 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef STATUS_H
 # define STATUS_H
+
+typedef struct s_shenv	t_shenv;
 
 /*
 	Functions that might fail should return one of these status codes. Errors
@@ -77,12 +79,12 @@ void		status_warn(const char *msg, const char *extra, int errnum);
 /*
 	Set the appropriate exit code if the status implies one.
 */
-void		status_set_exit_code(t_status status, int *exit_code);
+void		status_set_exit_code(t_status status, t_shenv *env);
 
 /*
 	Set the appropriate exit code if the status implies one, and replace the
 	status with S_EXIT_OK.
 */
-t_status	status_force_exit(t_status status, int *exit_code);
+t_status	status_force_exit(t_status status, t_shenv *env);
 
 #endif

--- a/include/word.h
+++ b/include/word.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/28 16:50:15 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/26 19:29:31 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 21:28:54 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,7 @@
 
 # include <stdbool.h>
 
+# include "shenv.h"
 # include "status.h"
 
 /*
@@ -29,9 +30,10 @@ struct s_word_field
 
 void		word_free(struct s_word_field *fields);
 
-t_status	word_expand(char *word, struct s_word_field ***fields_append);
+t_status	word_expand(char *word, struct s_word_field ***fields_append,
+				t_shenv *env);
 
 bool		word_heredoc_delimiter(char *word);
-t_status	word_heredoc_line(char **line);
+t_status	word_heredoc_line(char **line, t_shenv *env);
 
 #endif

--- a/src/builtin/builtin_cmd_cd.c
+++ b/src/builtin/builtin_cmd_cd.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 22:30:02 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/05 00:01:57 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/05 00:02:21 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,14 +39,13 @@ static t_status	get_cd_path(char **argv, t_shenv *env, char **path)
 /*
 	cd builtin command - changes the current working directory
 */
-t_status	builtin_cmd_cd(char **argv, t_shenv *env,
-	int *exit_code, int stdout_fd)
+t_status	builtin_cmd_cd(char **argv, t_shenv *env, int stdout_fd)
 {
 	t_status	status;
 	char		*path;
 
 	(void)stdout_fd;
-	*exit_code = 0;
+	env->exit_code = 0;
 	status = get_cd_path(argv, env, &path);
 	if (status != S_OK)
 		return (status);

--- a/src/builtin/builtin_cmd_cd.c
+++ b/src/builtin/builtin_cmd_cd.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 22:30:02 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 23:56:23 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/05 00:01:57 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,17 +15,17 @@
 #include <errno.h>
 #include <unistd.h>
 
-#include "env.h"
+#include "shenv.h"
 #include "status.h"
 
 /*
 	Determines the target path for cd command
 */
-static t_status	get_cd_path(char **argv, t_env *env, char **path)
+static t_status	get_cd_path(char **argv, t_shenv *env, char **path)
 {
 	if (!argv[1])
 	{
-		*path = env_get(env, "HOME");
+		*path = shenv_var_get(env, "HOME");
 		if (!*path)
 			return (status_err(S_BUILTIN_ERR, "cd", "HOME not set", 0));
 	}
@@ -39,7 +39,7 @@ static t_status	get_cd_path(char **argv, t_env *env, char **path)
 /*
 	cd builtin command - changes the current working directory
 */
-t_status	builtin_cmd_cd(char **argv, t_env *env,
+t_status	builtin_cmd_cd(char **argv, t_shenv *env,
 	int *exit_code, int stdout_fd)
 {
 	t_status	status;

--- a/src/builtin/builtin_cmd_echo.c
+++ b/src/builtin/builtin_cmd_echo.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_cmd_echo.c                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/12 20:09:35 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/03 15:20:39 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,8 @@
 
 #include <errno.h>
 
-#include "env.h"
 #include "libft.h"
+#include "shenv.h"
 #include "status.h"
 #include "util.h"
 
@@ -46,7 +46,7 @@ static t_status	write_args(char **argv, int stdout_fd,
 /*
 	echo builtin command - displays a line of text
 */
-t_status	builtin_cmd_echo(char **argv, t_env *env,
+t_status	builtin_cmd_echo(char **argv, t_shenv *env,
 	int *exit_code, int stdout_fd)
 {
 	bool	newline;

--- a/src/builtin/builtin_cmd_echo.c
+++ b/src/builtin/builtin_cmd_echo.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/12 20:09:35 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:43:52 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,12 +46,11 @@ static t_status	write_args(char **argv, int stdout_fd,
 /*
 	echo builtin command - displays a line of text
 */
-t_status	builtin_cmd_echo(char **argv, t_shenv *env,
-	int *exit_code, int stdout_fd)
+t_status	builtin_cmd_echo(char **argv, t_shenv *env, int stdout_fd)
 {
 	bool	newline;
 
-	*exit_code = 0;
+	env->exit_code = 0;
 	(void)env;
 	newline = true;
 	argv++;

--- a/src/builtin/builtin_cmd_env.c
+++ b/src/builtin/builtin_cmd_env.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_cmd_env.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 23:15:02 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/03 15:05:32 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,15 +14,15 @@
 
 #include <errno.h>
 
-#include "env.h"
 #include "libft.h"
+#include "shenv.h"
 #include "status.h"
 #include "util.h"
 
 /*
 	Prints all environment variables in the format KEY=VALUE
 */
-t_status	builtin_cmd_env(char **argv, t_env *env,
+t_status	builtin_cmd_env(char **argv, t_shenv *env,
 	int *exit_code, int stdout_fd)
 {
 	size_t	i;
@@ -32,9 +32,9 @@ t_status	builtin_cmd_env(char **argv, t_env *env,
 	(void)argv;
 	*exit_code = 0;
 	i = 0;
-	while (i < env->used_size)
+	while (i < env->var_array_used)
 	{
-		s = env->env_array[i];
+		s = env->var_array[i];
 		len = ft_strlen(s);
 		s[len] = '\n';
 		if (!util_write_all(stdout_fd, s, len + 1))

--- a/src/builtin/builtin_cmd_env.c
+++ b/src/builtin/builtin_cmd_env.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 23:15:02 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:43:52 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,15 +22,14 @@
 /*
 	Prints all environment variables in the format KEY=VALUE
 */
-t_status	builtin_cmd_env(char **argv, t_shenv *env,
-	int *exit_code, int stdout_fd)
+t_status	builtin_cmd_env(char **argv, t_shenv *env, int stdout_fd)
 {
 	size_t	i;
 	size_t	len;
 	char	*s;
 
 	(void)argv;
-	*exit_code = 0;
+	env->exit_code = 0;
 	i = 0;
 	while (i < env->var_array_used)
 	{

--- a/src/builtin/builtin_cmd_exit.c
+++ b/src/builtin/builtin_cmd_exit.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/12 15:26:54 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/12 16:06:30 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,11 +14,11 @@
 
 #include <stddef.h>
 
-#include "env.h"
+#include "shenv.h"
 #include "status.h"
 #include "util.h"
 
-t_status	builtin_cmd_exit(char	**argv, t_env *env,
+t_status	builtin_cmd_exit(char	**argv, t_shenv *env,
 	int *exit_code, int stdout_fd)
 {
 	size_t		parsed_len;

--- a/src/builtin/builtin_cmd_exit.c
+++ b/src/builtin/builtin_cmd_exit.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/12 15:26:54 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:43:52 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,8 +18,7 @@
 #include "status.h"
 #include "util.h"
 
-t_status	builtin_cmd_exit(char	**argv, t_shenv *env,
-	int *exit_code, int stdout_fd)
+t_status	builtin_cmd_exit(char	**argv, t_shenv *env, int stdout_fd)
 {
 	size_t		parsed_len;
 	int			parsed_value;
@@ -30,7 +29,7 @@ t_status	builtin_cmd_exit(char	**argv, t_shenv *env,
 	if (argv[2])
 	{
 		status_warn("exit: too many arguments", NULL, 0);
-		*exit_code = 2;
+		env->exit_code = 2;
 	}
 	else if (!util_parse_int(argv[1], &parsed_len, &parsed_value)
 		|| argv[1][parsed_len] != '\0'
@@ -38,9 +37,9 @@ t_status	builtin_cmd_exit(char	**argv, t_shenv *env,
 		|| parsed_value > 255)
 	{
 		status_warn("exit: argument out of range (0-255)", NULL, 0);
-		*exit_code = 2;
+		env->exit_code = 2;
 	}
 	else
-		*exit_code = parsed_value;
+		env->exit_code = parsed_value;
 	return (S_EXIT_OK);
 }

--- a/src/builtin/builtin_cmd_export.c
+++ b/src/builtin/builtin_cmd_export.c
@@ -3,18 +3,18 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_cmd_export.c                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 23:30:02 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/03 16:11:14 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtin_internal.h"
 #include "builtin_cmd_export_utils.h"
 
-#include "env.h"
 #include "libft.h"
+#include "shenv.h"
 #include "status.h"
 
 /*
@@ -40,7 +40,7 @@ static bool	extract_key_value(char *arg, char **key_out,
 	Handles a single export argument
 	Validates the identifier
 */
-static t_status	handle_export_arg(char *arg, t_env *env, int *exit_code)
+static t_status	handle_export_arg(char *arg, t_shenv *env, int *exit_code)
 {
 	char		*key;
 	char		*value;
@@ -53,13 +53,13 @@ static t_status	handle_export_arg(char *arg, t_env *env, int *exit_code)
 		*exit_code = 2;
 		return (S_OK);
 	}
-	return (env_set(env, key, value));
+	return (shenv_var_set(env, key, value));
 }
 
 /*
 	export builtin command - sets environment variables
 */
-t_status	builtin_cmd_export(char **argv, t_env *env,
+t_status	builtin_cmd_export(char **argv, t_shenv *env,
 	int *exit_code, int stdout_fd)
 {
 	int			i;

--- a/src/builtin/builtin_cmd_export.c
+++ b/src/builtin/builtin_cmd_export.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 23:30:02 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:44:30 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,7 +40,7 @@ static bool	extract_key_value(char *arg, char **key_out,
 	Handles a single export argument
 	Validates the identifier
 */
-static t_status	handle_export_arg(char *arg, t_shenv *env, int *exit_code)
+static t_status	handle_export_arg(char *arg, t_shenv *env)
 {
 	char		*key;
 	char		*value;
@@ -50,7 +50,7 @@ static t_status	handle_export_arg(char *arg, t_shenv *env, int *exit_code)
 	if (!is_valid_identifier(key))
 	{
 		status_warn("export: not a valid identifier", key, 0);
-		*exit_code = 2;
+		env->exit_code = 2;
 		return (S_OK);
 	}
 	return (shenv_var_set(env, key, value));
@@ -59,19 +59,18 @@ static t_status	handle_export_arg(char *arg, t_shenv *env, int *exit_code)
 /*
 	export builtin command - sets environment variables
 */
-t_status	builtin_cmd_export(char **argv, t_shenv *env,
-	int *exit_code, int stdout_fd)
+t_status	builtin_cmd_export(char **argv, t_shenv *env, int stdout_fd)
 {
 	int			i;
 	t_status	status;
 
-	*exit_code = 0;
+	env->exit_code = 0;
 	if (!argv[1])
 		return (print_exports(env, stdout_fd));
 	i = 1;
 	while (argv[i])
 	{
-		status = handle_export_arg(argv[i], env, exit_code);
+		status = handle_export_arg(argv[i], env);
 		if (status != S_OK)
 			return (status);
 		i++;

--- a/src/builtin/builtin_cmd_export_utils.c
+++ b/src/builtin/builtin_cmd_export_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_cmd_export_utils.c                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 23:30:02 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/03 16:26:26 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,8 +15,8 @@
 #include <errno.h>
 #include <stdlib.h>
 
-#include "env.h"
 #include "libft.h"
+#include "shenv.h"
 #include "status.h"
 #include "util.h"
 
@@ -106,7 +106,7 @@ static t_status	process_export_entry(char *env_str, char **buffer,
 	Prints all environment variables in the format "declare -x KEY="VALUE""
 	For variables without values, prints just "declare -x KEY"
 */
-t_status	print_exports(t_env *env, int stdout_fd)
+t_status	print_exports(t_shenv *env, int stdout_fd)
 {
 	t_status	status;
 	size_t		i;
@@ -117,9 +117,9 @@ t_status	print_exports(t_env *env, int stdout_fd)
 	buffer = NULL;
 	i = 0;
 	status = S_OK;
-	while (i < env->used_size && status == S_OK)
+	while (i < env->var_array_used && status == S_OK)
 	{
-		status = process_export_entry(env->env_array[i], &buffer,
+		status = process_export_entry(env->var_array[i], &buffer,
 				&buffer_size, stdout_fd);
 		i++;
 	}

--- a/src/builtin/builtin_cmd_export_utils.h
+++ b/src/builtin/builtin_cmd_export_utils.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_cmd_export_utils.h                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 23:30:02 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/03 15:21:35 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,10 +14,11 @@
 # define BUILTIN_CMD_EXPORT_UTILS_H
 
 # include <stdbool.h>
-# include "env.h"
+
+# include "shenv.h"
 # include "status.h"
 
-t_status	print_exports(t_env *env, int stdout_fd);
+t_status	print_exports(t_shenv *env, int stdout_fd);
 bool		is_valid_identifier(const char *str);
 
 #endif

--- a/src/builtin/builtin_cmd_pwd.c
+++ b/src/builtin/builtin_cmd_pwd.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/12 20:54:02 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:43:52 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,20 +39,19 @@ static t_status	write_cwd(char *cwd, int stdout_fd)
  	Prints the current working directory
 	Note: getcwd(NULL, 0) is a glibc extension, not POSIX standard
 */
-t_status	builtin_cmd_pwd(char **argv, t_shenv *env,
-	int *exit_code, int stdout_fd)
+t_status	builtin_cmd_pwd(char **argv, t_shenv *env, int stdout_fd)
 {
 	char		*cwd;
 	t_status	status;
 
 	(void)argv;
 	(void)env;
-	*exit_code = 0;
+	env->exit_code = 0;
 	cwd = getcwd(NULL, 0);
 	if (!cwd)
 	{
 		status_warn("pwd: getcwd failed", NULL, errno);
-		*exit_code = 1;
+		env->exit_code = 1;
 		return (S_OK);
 	}
 	status = write_cwd(cwd, stdout_fd);

--- a/src/builtin/builtin_cmd_pwd.c
+++ b/src/builtin/builtin_cmd_pwd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_cmd_pwd.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/12 20:54:02 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/03 16:10:28 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,8 +16,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include "env.h"
 #include "libft.h"
+#include "shenv.h"
 #include "status.h"
 #include "util.h"
 
@@ -39,7 +39,7 @@ static t_status	write_cwd(char *cwd, int stdout_fd)
  	Prints the current working directory
 	Note: getcwd(NULL, 0) is a glibc extension, not POSIX standard
 */
-t_status	builtin_cmd_pwd(char **argv, t_env *env,
+t_status	builtin_cmd_pwd(char **argv, t_shenv *env,
 	int *exit_code, int stdout_fd)
 {
 	char		*cwd;

--- a/src/builtin/builtin_cmd_unset.c
+++ b/src/builtin/builtin_cmd_unset.c
@@ -3,22 +3,22 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_cmd_unset.c                                :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 23:45:02 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/03 16:42:49 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtin_internal.h"
 
-#include "env.h"
+#include "shenv.h"
 #include "status.h"
 
 /*
 	unset builtin command - removes environment variables
 */
-t_status	builtin_cmd_unset(char **argv, t_env *env,
+t_status	builtin_cmd_unset(char **argv, t_shenv *env,
 	int *exit_code, int stdout_fd)
 {
 	int			i;
@@ -31,7 +31,7 @@ t_status	builtin_cmd_unset(char **argv, t_env *env,
 	i = 1;
 	while (argv[i])
 	{
-		status = env_unset(env, argv[i]);
+		status = shenv_var_unset(env, argv[i]);
 		if (status != S_OK)
 			return (status);
 		i++;

--- a/src/builtin/builtin_cmd_unset.c
+++ b/src/builtin/builtin_cmd_unset.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/14 23:45:02 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:43:52 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,14 +18,13 @@
 /*
 	unset builtin command - removes environment variables
 */
-t_status	builtin_cmd_unset(char **argv, t_shenv *env,
-	int *exit_code, int stdout_fd)
+t_status	builtin_cmd_unset(char **argv, t_shenv *env, int stdout_fd)
 {
 	int			i;
 	t_status	status;
 
 	(void)stdout_fd;
-	*exit_code = 0;
+	env->exit_code = 0;
 	if (!argv[1])
 		return (S_OK);
 	i = 1;

--- a/src/builtin/builtin_internal.h
+++ b/src/builtin/builtin_internal.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_internal.h                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/12 15:19:36 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/17 20:05:33 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
 
 # include "builtin.h"
 
-# include "env.h"
+# include "shenv.h"
 # include "status.h"
 
 struct s_builtin_func_reg
@@ -24,19 +24,19 @@ struct s_builtin_func_reg
 	const char		*name;
 };
 
-t_status	builtin_cmd_exit(char	**argv, t_env *env,
+t_status	builtin_cmd_exit(char	**argv, t_shenv *env,
 				int *exit_code, int stdout_fd);
-t_status	builtin_cmd_echo(char **argv, t_env *env,
+t_status	builtin_cmd_echo(char **argv, t_shenv *env,
 				int *exit_code, int stdout_fd);
-t_status	builtin_cmd_pwd(char	**argv, t_env *env,
+t_status	builtin_cmd_pwd(char	**argv, t_shenv *env,
 				int *exit_code, int stdout_fd);
-t_status	builtin_cmd_cd(char **argv, t_env *env,
+t_status	builtin_cmd_cd(char **argv, t_shenv *env,
 				int *exit_code, int stdout_fd);
-t_status	builtin_cmd_env(char **argv, t_env *env,
+t_status	builtin_cmd_env(char **argv, t_shenv *env,
 				int *exit_code, int stdout_fd);
-t_status	builtin_cmd_export(char **argv, t_env *env,
+t_status	builtin_cmd_export(char **argv, t_shenv *env,
 				int *exit_code, int stdout_fd);
-t_status	builtin_cmd_unset(char **argv, t_env *env,
+t_status	builtin_cmd_unset(char **argv, t_shenv *env,
 				int *exit_code, int stdout_fd);
 
 #endif

--- a/src/builtin/builtin_internal.h
+++ b/src/builtin/builtin_internal.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/12 15:19:36 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:40:31 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,19 +24,12 @@ struct s_builtin_func_reg
 	const char		*name;
 };
 
-t_status	builtin_cmd_exit(char	**argv, t_shenv *env,
-				int *exit_code, int stdout_fd);
-t_status	builtin_cmd_echo(char **argv, t_shenv *env,
-				int *exit_code, int stdout_fd);
-t_status	builtin_cmd_pwd(char	**argv, t_shenv *env,
-				int *exit_code, int stdout_fd);
-t_status	builtin_cmd_cd(char **argv, t_shenv *env,
-				int *exit_code, int stdout_fd);
-t_status	builtin_cmd_env(char **argv, t_shenv *env,
-				int *exit_code, int stdout_fd);
-t_status	builtin_cmd_export(char **argv, t_shenv *env,
-				int *exit_code, int stdout_fd);
-t_status	builtin_cmd_unset(char **argv, t_shenv *env,
-				int *exit_code, int stdout_fd);
+t_status	builtin_cmd_exit(char **argv, t_shenv *env, int stdout_fd);
+t_status	builtin_cmd_echo(char **argv, t_shenv *env, int stdout_fd);
+t_status	builtin_cmd_pwd(char **argv, t_shenv *env, int stdout_fd);
+t_status	builtin_cmd_cd(char **argv, t_shenv *env, int stdout_fd);
+t_status	builtin_cmd_env(char **argv, t_shenv *env, int stdout_fd);
+t_status	builtin_cmd_export(char **argv, t_shenv *env, int stdout_fd);
+t_status	builtin_cmd_unset(char **argv, t_shenv *env, int stdout_fd);
 
 #endif

--- a/src/execute/execute_internal.h
+++ b/src/execute/execute_internal.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:27:27 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 22:18:36 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 22:39:58 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,8 +42,6 @@ t_status	execute_pipeline(struct s_ast_simple_command *pipeline_head,
 t_status	execute_simple_command(struct s_ast_simple_command *command,
 				t_shenv *env, bool is_child);
 
-int			process_heredoc(struct s_ast_redirect *redirect);
-
 struct s_redir_fds
 {
 	int	in;
@@ -51,6 +49,9 @@ struct s_redir_fds
 };
 
 # define NO_REDIR -1
+
+t_status	execute_redirect_heredoc(struct s_ast_redirect *redirect,
+				struct s_redir_fds *fds);
 
 t_status	execute_redirect_prepare(struct s_redir_fds *fds,
 				struct s_ast_redirect *redirs);

--- a/src/execute/execute_internal.h
+++ b/src/execute/execute_internal.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:27:27 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/29 19:19:38 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,16 +16,16 @@
 # include <stdbool.h>
 
 # include "ast.h"
-# include "env.h"
+# include "shenv.h"
 # include "status.h"
 
 /*
 	Internal functions for command execution
 	These functions handle the finding and executing external commands
 */
-void		handle_absolute_path(char **argv, t_env *env, int *exit_code);
+void		handle_absolute_path(char **argv, t_shenv *env, int *exit_code);
 
-void		handle_path_search(char **argv, t_env *env, int *exit_code);
+void		handle_path_search(char **argv, t_shenv *env, int *exit_code);
 
 struct	s_pipeline_fds
 {

--- a/src/execute/execute_internal.h
+++ b/src/execute/execute_internal.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:27:27 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 22:39:58 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 23:27:47 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,10 +51,10 @@ struct s_redir_fds
 # define NO_REDIR -1
 
 t_status	execute_redirect_heredoc(struct s_ast_redirect *redirect,
-				struct s_redir_fds *fds);
+				struct s_redir_fds *fds, t_shenv *env);
 
 t_status	execute_redirect_prepare(struct s_redir_fds *fds,
-				struct s_ast_redirect *redirs);
+				struct s_ast_redirect *redirs, t_shenv *env);
 t_status	execute_redirect_finish(struct s_redir_fds *fds, bool apply);
 
 #endif

--- a/src/execute/execute_internal.h
+++ b/src/execute/execute_internal.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:27:27 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:37:58 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,9 +23,9 @@
 	Internal functions for command execution
 	These functions handle the finding and executing external commands
 */
-void		handle_absolute_path(char **argv, t_shenv *env, int *exit_code);
+void		handle_absolute_path(char **argv, t_shenv *env);
 
-void		handle_path_search(char **argv, t_shenv *env, int *exit_code);
+void		handle_path_search(char **argv, t_shenv *env);
 
 struct	s_pipeline_fds
 {

--- a/src/execute/execute_internal.h
+++ b/src/execute/execute_internal.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:27:27 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 20:37:58 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 22:18:36 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,6 +35,14 @@ struct	s_pipeline_fds
 };
 
 # define NO_PIPE -1
+
+t_status	execute_pipeline(struct s_ast_simple_command *pipeline_head,
+				t_shenv *env);
+
+t_status	execute_simple_command(struct s_ast_simple_command *command,
+				t_shenv *env, bool is_child);
+
+int			process_heredoc(struct s_ast_redirect *redirect);
 
 struct s_redir_fds
 {

--- a/src/execute/execute_redirect.c
+++ b/src/execute/execute_redirect.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/28 17:47:16 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/29 19:19:38 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 22:37:54 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,27 +24,9 @@
 #include "word.h"
 
 /*
-	TODO (entire file): Does close error need handling? Store path with fds for
-	close error?
+	TODO: Does close error need handling? Store path with fds for
+	close error? Also applies to execute_redirect_heredoc.
 */
-
-/*
-	Prepare heredoc for redirection and store the file descriptor in the correct
-	fds field. If the field holds another file descriptor, close it first.
-
-	No error message printed here, because process_heredoc prints its own.
-	TODO: Refactor heredoc handling to skip this wrapper.
-*/
-static t_status	execute_redirect_heredoc(struct s_ast_redirect *redir,
-	struct s_redir_fds *fds)
-{
-	if (fds->in != NO_REDIR)
-		close(fds->in);
-	fds->in = process_heredoc(redir);
-	if (fds->in == -1)
-		return (S_COMM_ERR);
-	return (S_OK);
-}
 
 /*
 	Open a path for redirection and store the file descriptor in the correct

--- a/src/execute/execute_redirect.c
+++ b/src/execute/execute_redirect.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/28 17:47:16 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 22:37:54 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 23:27:37 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,7 @@
 #include <unistd.h>
 
 #include "ast.h"
+#include "shenv.h"
 #include "status.h"
 #include "word.h"
 
@@ -57,7 +58,7 @@ static t_status	execute_redirect_open(enum e_ast_redirect_op op,
 	doesn't generate exactly one field, an error is reported instead.
 */
 static t_status	execute_redirect_file(struct s_ast_redirect *redir,
-	struct s_redir_fds *fds)
+	struct s_redir_fds *fds, t_shenv *env)
 {
 	t_status			status;
 	struct s_word_field	*expanded;
@@ -65,7 +66,7 @@ static t_status	execute_redirect_file(struct s_ast_redirect *redir,
 
 	expanded = NULL;
 	exp_append = &expanded;
-	status = word_expand(redir->word, &exp_append);
+	status = word_expand(redir->word, &exp_append, env);
 	if (status == S_OK && expanded && !expanded->next)
 		status = execute_redirect_open(redir->op, expanded->value, fds);
 	else if (status == S_OK)
@@ -110,7 +111,7 @@ t_status	execute_redirect_finish(struct s_redir_fds *fds, bool apply)
 	undefined.
 */
 t_status	execute_redirect_prepare(struct s_redir_fds *fds,
-	struct s_ast_redirect *redirs)
+	struct s_ast_redirect *redirs, t_shenv *env)
 {
 	t_status				status;
 	enum e_ast_redirect_op	op;
@@ -122,9 +123,9 @@ t_status	execute_redirect_prepare(struct s_redir_fds *fds,
 	{
 		op = redirs->op;
 		if (op == AST_REDIR_IN || op == AST_REDIR_OUT || op == AST_REDIR_APP)
-			status = execute_redirect_file(redirs, fds);
+			status = execute_redirect_file(redirs, fds, env);
 		else if (op == AST_HEREDOC)
-			status = execute_redirect_heredoc(redirs, fds);
+			status = execute_redirect_heredoc(redirs, fds, env);
 		else
 			status = status_err(S_EXIT_ERR, "execute_redirect: internal error",
 					"invalid ast_redirect type", 0);

--- a/src/execute/heredoc.c
+++ b/src/execute/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/29 15:10:22 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 22:57:06 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 23:28:06 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,7 +75,7 @@ static t_status	execute_heredoc_create(int *writefd_out, int *readfd_out)
 	in case some other code tries to process the string after this function.
 */
 static t_status	execute_heredoc_write(int fd, bool quoted,
-	struct s_ast_command_word *lines)
+	struct s_ast_command_word *lines, t_shenv *env)
 {
 	t_status					status;
 	struct s_ast_command_word	*current;
@@ -86,7 +86,7 @@ static t_status	execute_heredoc_write(int fd, bool quoted,
 	{
 		if (!quoted)
 		{
-			status = word_heredoc_line(&current->word);
+			status = word_heredoc_line(&current->word, env);
 			if (status != S_OK)
 				return (status);
 		}
@@ -111,7 +111,7 @@ static t_status	execute_heredoc_write(int fd, bool quoted,
 	file descriptor for the redirection.
 */
 t_status	execute_redirect_heredoc(struct s_ast_redirect *redirect,
-	struct s_redir_fds *fds)
+	struct s_redir_fds *fds, t_shenv *env)
 {
 	t_status	status;
 	int			writefd;
@@ -123,7 +123,7 @@ t_status	execute_redirect_heredoc(struct s_ast_redirect *redirect,
 	if (status != S_OK)
 		return (status);
 	status = execute_heredoc_write(writefd, redirect->heredoc_quoted,
-			redirect->heredoc_lines);
+			redirect->heredoc_lines, env);
 	if (close(writefd) < 0)
 		if (status == S_OK)
 			status = status_err(S_COMM_ERR, "execute_heredoc",

--- a/src/execute/list.c
+++ b/src/execute/list.c
@@ -6,11 +6,12 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/04 13:35:32 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 20:43:05 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 22:19:05 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "execute.h"
+#include "execute_internal.h"
 
 #include <stdbool.h>
 

--- a/src/execute/list.c
+++ b/src/execute/list.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/04 13:35:32 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/21 03:59:59 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
 #include <stdbool.h>
 
 #include "ast.h"
-#include "env.h"
+#include "shenv.h"
 #include "status.h"
 
 /*
@@ -24,7 +24,7 @@
 	The error case should be impossible to hit if the parser works correctly.
 */
 static t_status	execute_list_entry(struct s_ast_list_entry *entry,
-	t_env *env, int *exit_code)
+	t_shenv *env, int *exit_code)
 {
 	if (entry->type == AST_LIST_PIPELINE)
 		return (execute_pipeline(entry->pipeline, env, exit_code));
@@ -40,7 +40,7 @@ static t_status	execute_list_entry(struct s_ast_list_entry *entry,
 	Commands are executed left to right, evaluating each action for AND/OR
 */
 t_status	execute_list(struct s_ast_list_entry *list_head,
-	t_env *env, int *exit_code)
+	t_shenv *env, int *exit_code)
 {
 	t_status	status;
 	bool		execute_next;

--- a/src/execute/list.c
+++ b/src/execute/list.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/04 13:35:32 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:43:05 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,13 +23,12 @@
 
 	The error case should be impossible to hit if the parser works correctly.
 */
-static t_status	execute_list_entry(struct s_ast_list_entry *entry,
-	t_shenv *env, int *exit_code)
+static t_status	execute_list_entry(struct s_ast_list_entry *entry, t_shenv *env)
 {
 	if (entry->type == AST_LIST_PIPELINE)
-		return (execute_pipeline(entry->pipeline, env, exit_code));
+		return (execute_pipeline(entry->pipeline, env));
 	else if (entry->type == AST_LIST_GROUP)
-		return (execute_list(entry->group, env, exit_code));
+		return (execute_list(entry->group, env));
 	else
 		return (status_err(S_EXIT_ERR, "execute_list: internal error",
 				"invalid ast_list_entry type", 0));
@@ -39,22 +38,23 @@ static t_status	execute_list_entry(struct s_ast_list_entry *entry,
 	Execute a command list, handling logical operators && and ||
 	Commands are executed left to right, evaluating each action for AND/OR
 */
-t_status	execute_list(struct s_ast_list_entry *list_head,
-	t_shenv *env, int *exit_code)
+t_status	execute_list(struct s_ast_list_entry *list_head, t_shenv *env)
 {
 	t_status	status;
 	bool		execute_next;
+	int			exit_code;
 
 	if (!list_head)
 		return (S_OK);
-	status = execute_list_entry(list_head, env, exit_code);
+	status = execute_list_entry(list_head, env);
 	while (list_head->next && status == S_OK)
 	{
-		execute_next = (list_head->next_op == AST_LIST_AND && *exit_code == 0)
-			|| (list_head->next_op == AST_LIST_OR && *exit_code != 0);
+		exit_code = env->exit_code;
+		execute_next = (list_head->next_op == AST_LIST_AND && exit_code == 0)
+			|| (list_head->next_op == AST_LIST_OR && exit_code != 0);
 		list_head = list_head->next;
 		if (execute_next)
-			status = execute_list_entry(list_head, env, exit_code);
+			status = execute_list_entry(list_head, env);
 	}
 	return (status);
 }

--- a/src/execute/path.c
+++ b/src/execute/path.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   path.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 12:02:43 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 18:59:13 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,9 +16,9 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include "env.h"
-#include "status.h"
 #include "libft.h"
+#include "shenv.h"
+#include "status.h"
 
 /*
 	Constructs a full path by joining a directory and command name
@@ -108,9 +108,9 @@ static int	try_path_execve(char *path_list, char **argv, char **envp)
 	Sets exit_code to 126 for permission denied, 127 for other errors
 	Reports appropriate error message using status_err
 */
-void	handle_absolute_path(char **argv, t_env *env, int *exit_code)
+void	handle_absolute_path(char **argv, t_shenv *env, int *exit_code)
 {
-	execve(argv[0], argv, env->env_array);
+	execve(argv[0], argv, env->var_array);
 	if (errno == EACCES)
 		*exit_code = 126;
 	else
@@ -123,14 +123,14 @@ void	handle_absolute_path(char **argv, t_env *env, int *exit_code)
 	Sets exit_code to 126 for permission denied, 127 for command not found
 	Reports appropriate error message using status_err
 */
-void	handle_path_search(char **argv, t_env *env, int *exit_code)
+void	handle_path_search(char **argv, t_shenv *env, int *exit_code)
 {
 	char	*path_var;
 	char	*path_copy;
 
 	if (ft_strchr(argv[0], '/'))
 		return (handle_absolute_path(argv, env, exit_code));
-	path_var = env_get(env, "PATH");
+	path_var = shenv_var_get(env, "PATH");
 	if (!path_var)
 	{
 		status_err(S_COMM_ERR, argv[0], "command not found", 0);
@@ -144,7 +144,7 @@ void	handle_path_search(char **argv, t_env *env, int *exit_code)
 		*exit_code = 127;
 		return ;
 	}
-	*exit_code = try_path_execve(path_copy, argv, env->env_array);
+	*exit_code = try_path_execve(path_copy, argv, env->var_array);
 	if (*exit_code == 126)
 		status_err(S_COMM_ERR, argv[0], "Permission denied", 0);
 	else

--- a/src/execute/path.c
+++ b/src/execute/path.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 12:02:43 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:44:30 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -108,13 +108,13 @@ static int	try_path_execve(char *path_list, char **argv, char **envp)
 	Sets exit_code to 126 for permission denied, 127 for other errors
 	Reports appropriate error message using status_err
 */
-void	handle_absolute_path(char **argv, t_shenv *env, int *exit_code)
+void	handle_absolute_path(char **argv, t_shenv *env)
 {
 	execve(argv[0], argv, env->var_array);
 	if (errno == EACCES)
-		*exit_code = 126;
+		env->exit_code = 126;
 	else
-		*exit_code = 127;
+		env->exit_code = 127;
 	status_err(S_COMM_ERR, argv[0], NULL, errno);
 }
 
@@ -123,29 +123,29 @@ void	handle_absolute_path(char **argv, t_shenv *env, int *exit_code)
 	Sets exit_code to 126 for permission denied, 127 for command not found
 	Reports appropriate error message using status_err
 */
-void	handle_path_search(char **argv, t_shenv *env, int *exit_code)
+void	handle_path_search(char **argv, t_shenv *env)
 {
 	char	*path_var;
 	char	*path_copy;
 
 	if (ft_strchr(argv[0], '/'))
-		return (handle_absolute_path(argv, env, exit_code));
+		return (handle_absolute_path(argv, env));
 	path_var = shenv_var_get(env, "PATH");
 	if (!path_var)
 	{
 		status_err(S_COMM_ERR, argv[0], "command not found", 0);
-		*exit_code = 127;
+		env->exit_code = 127;
 		return ;
 	}
 	path_copy = ft_strdup(path_var);
 	if (!path_copy)
 	{
 		status_err(S_COMM_ERR, "malloc", NULL, errno);
-		*exit_code = 127;
+		env->exit_code = 127;
 		return ;
 	}
-	*exit_code = try_path_execve(path_copy, argv, env->var_array);
-	if (*exit_code == 126)
+	env->exit_code = try_path_execve(path_copy, argv, env->var_array);
+	if (env->exit_code == 126)
 		status_err(S_COMM_ERR, argv[0], "Permission denied", 0);
 	else
 		status_err(S_COMM_ERR, argv[0], "command not found", 0);

--- a/src/execute/pipeline.c
+++ b/src/execute/pipeline.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/24 17:13:08 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/29 21:43:29 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,7 @@
 #include <unistd.h>
 
 #include "ast.h"
-#include "env.h"
+#include "shenv.h"
 #include "status.h"
 
 /*
@@ -65,7 +65,7 @@ static t_status	execute_pipeline_create_pipe_and_fork(
 	written anything yet anyway.
 */
 static t_status	execute_pipeline_child(struct s_pipeline_fds *fds,
-	struct s_ast_simple_command *child_command, t_env *env, int *exit_code)
+	struct s_ast_simple_command *child_command, t_shenv *env, int *exit_code)
 {
 	t_status	status;
 
@@ -156,7 +156,7 @@ static t_status	execute_pipeline_wait_for_children(
 	each command to the stdin of the next one.
 */
 t_status	execute_pipeline(struct s_ast_simple_command *pipeline_head,
-	t_env *env, int *exit_code)
+	t_shenv *env, int *exit_code)
 {
 	t_status				status;
 	pid_t					child;

--- a/src/execute/pipeline.c
+++ b/src/execute/pipeline.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/24 17:13:08 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:45:58 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,7 +65,7 @@ static t_status	execute_pipeline_create_pipe_and_fork(
 	written anything yet anyway.
 */
 static t_status	execute_pipeline_child(struct s_pipeline_fds *fds,
-	struct s_ast_simple_command *child_command, t_shenv *env, int *exit_code)
+	struct s_ast_simple_command *child_command, t_shenv *env)
 {
 	t_status	status;
 
@@ -87,7 +87,7 @@ static t_status	execute_pipeline_child(struct s_pipeline_fds *fds,
 		close(fds->out);
 	}
 	if (status == S_OK)
-		status = execute_simple_command(child_command, env, exit_code, true);
+		status = execute_simple_command(child_command, env, true);
 	return (status);
 }
 
@@ -124,7 +124,7 @@ static void	execute_pipeline_cleanup(struct s_pipeline_fds *fds, bool had_error)
 	error case should be impossible to hit, but no harm in checking.
 */
 static t_status	execute_pipeline_wait_for_children(
-	t_status status, pid_t last_child, int *exit_code)
+	t_status status, pid_t last_child, t_shenv *env)
 {
 	int		wait_status;
 	pid_t	waited_child;
@@ -144,9 +144,9 @@ static t_status	execute_pipeline_wait_for_children(
 		if (waited_child == last_child)
 		{
 			if (WIFEXITED(wait_status))
-				*exit_code = WEXITSTATUS(wait_status);
+				env->exit_code = WEXITSTATUS(wait_status);
 			else if (WIFSIGNALED(wait_status))
-				*exit_code = 128 + WTERMSIG(wait_status);
+				env->exit_code = 128 + WTERMSIG(wait_status);
 		}
 	}
 }
@@ -156,7 +156,7 @@ static t_status	execute_pipeline_wait_for_children(
 	each command to the stdin of the next one.
 */
 t_status	execute_pipeline(struct s_ast_simple_command *pipeline_head,
-	t_shenv *env, int *exit_code)
+	t_shenv *env)
 {
 	t_status				status;
 	pid_t					child;
@@ -167,19 +167,18 @@ t_status	execute_pipeline(struct s_ast_simple_command *pipeline_head,
 	first = true;
 	child = 0;
 	if (pipeline_head && !pipeline_head->next)
-		return (execute_simple_command(pipeline_head, env, exit_code, false));
+		return (execute_simple_command(pipeline_head, env, false));
 	while (pipeline_head)
 	{
 		status = execute_pipeline_create_pipe_and_fork(
 				&fds, first, !pipeline_head->next, &child);
 		if (status == S_OK && child == 0)
-			return (execute_pipeline_child(&fds, pipeline_head, env,
-					exit_code));
+			return (execute_pipeline_child(&fds, pipeline_head, env));
 		execute_pipeline_cleanup(&fds, status != S_OK);
 		if (status != S_OK)
 			break ;
 		pipeline_head = pipeline_head->next;
 		first = false;
 	}
-	return (execute_pipeline_wait_for_children(status, child, exit_code));
+	return (execute_pipeline_wait_for_children(status, child, env));
 }

--- a/src/execute/simple_command.c
+++ b/src/execute/simple_command.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:21:06 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 20:46:25 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 21:42:42 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,7 +72,7 @@ static t_status	execute_arg_fields_to_argv(
 	are set to null pointers.
 */
 static t_status	execute_expand_args(struct s_ast_command_word *args,
-	struct s_word_field **fields_out, char ***argv_out)
+	struct s_word_field **fields_out, char ***argv_out, t_shenv *env)
 {
 	t_status			status;
 	struct s_word_field	**fields_append;
@@ -82,7 +82,7 @@ static t_status	execute_expand_args(struct s_ast_command_word *args,
 	fields_append = fields_out;
 	while (args)
 	{
-		status = word_expand(args->word, &fields_append);
+		status = word_expand(args->word, &fields_append, env);
 		if (status != S_OK)
 			return (status);
 		args = args->next;
@@ -139,7 +139,7 @@ static t_status	execute_command_execute(struct s_ast_redirect *redirs,
 	t_builtin_func		*builtin;
 	bool				is_external;
 
-	status = execute_redirect_prepare(&fds, redirs);
+	status = execute_redirect_prepare(&fds, redirs, env);
 	if (status != S_OK)
 		return (status);
 	builtin = NULL;
@@ -175,7 +175,7 @@ t_status	execute_simple_command(struct s_ast_simple_command *command,
 	char				**argv;
 	bool				need_child;
 
-	status = execute_expand_args(command->args, &arg_fields, &argv);
+	status = execute_expand_args(command->args, &arg_fields, &argv, env);
 	if (status == S_OK)
 		need_child = argv && !builtin_get_func(argv[0]);
 	if (status == S_OK && need_child && !is_child)

--- a/src/execute/simple_command.c
+++ b/src/execute/simple_command.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:21:06 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/29 20:09:55 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@
 
 #include "ast.h"
 #include "builtin.h"
-#include "env.h"
+#include "shenv.h"
 #include "status.h"
 #include "word.h"
 
@@ -132,7 +132,7 @@ static t_status	execute_command_fork(bool *is_child, int *exit_code)
 	and close them afterwards.
 */
 static t_status	execute_command_execute(struct s_ast_redirect *redirs,
-	char **argv, t_env *env, int *exit_code)
+	char **argv, t_shenv *env, int *exit_code)
 {
 	t_status			status;
 	struct s_redir_fds	fds;
@@ -168,7 +168,7 @@ static t_status	execute_command_execute(struct s_ast_redirect *redirs,
 	process to exit instead of staying around as a duplicate shell instance.
 */
 t_status	execute_simple_command(struct s_ast_simple_command *command,
-	t_env *env, int *exit_code, bool is_child)
+	t_shenv *env, int *exit_code, bool is_child)
 {
 	t_status			status;
 	struct s_word_field	*arg_fields;

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/11 15:55:33 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/29 21:22:04 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,10 +18,10 @@
 #include "ast.h"
 #include "parser.h"
 #include "execute.h"
-#include "env.h"
+#include "shenv.h"
 #include "status.h"
 
-static t_status	minishell_do_line(t_env *env, int *exit_code)
+static t_status	minishell_do_line(t_shenv *env, int *exit_code)
 {
 	t_status				status;
 	char					*line;
@@ -44,15 +44,15 @@ static t_status	minishell_do_line(t_env *env, int *exit_code)
 int	main(void)
 {
 	t_status	status;
-	t_env		env;
+	t_shenv		env;
 	int			exit_code;
 
 	exit_code = 0;
-	status = env_init(&env);
+	status = shenv_init(&env);
 	if (status != S_OK)
 		return (1);
 	while (status != S_EXIT_ERR && status != S_EXIT_OK)
 		status = minishell_do_line(&env, &exit_code);
-	env_free(&env);
+	shenv_free(&env);
 	return (exit_code);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/11 15:55:33 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 21:02:55 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,7 @@
 #include "shenv.h"
 #include "status.h"
 
-static t_status	minishell_do_line(t_shenv *env, int *exit_code)
+static t_status	minishell_do_line(t_shenv *env)
 {
 	t_status				status;
 	char					*line;
@@ -35,9 +35,9 @@ static t_status	minishell_do_line(t_shenv *env, int *exit_code)
 		add_history(line);
 	free(line);
 	if (status == S_OK)
-		status = execute_list(ast, env, exit_code);
+		status = execute_list(ast, env);
 	free_ast(ast);
-	status_set_exit_code(status, exit_code);
+	status_set_exit_code(status, env);
 	return (status);
 }
 
@@ -45,14 +45,12 @@ int	main(void)
 {
 	t_status	status;
 	t_shenv		env;
-	int			exit_code;
 
-	exit_code = 0;
 	status = shenv_init(&env);
 	if (status != S_OK)
 		return (1);
 	while (status != S_EXIT_ERR && status != S_EXIT_OK)
-		status = minishell_do_line(&env, &exit_code);
+		status = minishell_do_line(&env);
 	shenv_free(&env);
-	return (exit_code);
+	return (env.exit_code);
 }

--- a/src/parser/parser_heredoc.c
+++ b/src/parser/parser_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/19 13:40:32 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 22:26:54 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 22:56:37 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,49 +51,30 @@ static t_status	add_line_to_heredoc(
 }
 
 /*
-	Process a line for the heredoc
-*/
-static t_status	process_heredoc_line(
-	struct s_heredoc_params *params)
-{
-	t_status	status;
-
-	status = S_OK;
-	if (!params->quoted)
-		status = word_heredoc_line(&params->line);
-	if (status == S_OK)
-		status = add_line_to_heredoc(&params->lines_append, params->line);
-	if (status != S_OK)
-		free(params->line);
-	return (status);
-}
-
-/*
 	Read heredoc content from stdin until the delimiter is encountered.
 	Store the content as a linked list of lines in the redirect node.
 */
 t_status	read_heredoc(struct s_ast_redirect *redirect)
 {
-	struct s_heredoc_params	params;
-	t_status				status;
+	t_status					status;
+	struct s_ast_command_word	**lines_append;
+	char						*delimiter;
+	size_t						delim_len;
+	char						*line;
 
 	redirect->heredoc_lines = NULL;
-	params.lines_append = &redirect->heredoc_lines;
-	params.quoted = word_heredoc_delimiter(redirect->word);
-	params.delimiter = redirect->word;
-	params.delim_len = ft_strlen(redirect->word);
+	lines_append = &redirect->heredoc_lines;
+	redirect->heredoc_quoted = word_heredoc_delimiter(redirect->word);
+	delimiter = redirect->word;
+	delim_len = ft_strlen(redirect->word);
 	status = S_OK;
 	while (status == S_OK)
 	{
-		params.line = readline("> ");
-		if (!params.line)
+		line = readline("> ");
+		if (is_delimiter(line, delimiter, delim_len))
 			break ;
-		if (is_delimiter(params.line, params.delimiter, params.delim_len))
-		{
-			free(params.line);
-			break ;
-		}
-		status = process_heredoc_line(&params);
+		status = add_line_to_heredoc(&lines_append, line);
 	}
+	free(line);
 	return (status);
 }

--- a/src/parser/parser_internal.h
+++ b/src/parser/parser_internal.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/31 16:49:57 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/12 22:43:47 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 23:24:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,16 +47,6 @@ t_status	parser_list(
 t_status	parser_group(
 				struct s_parser_state *state,
 				struct s_ast_list_entry **group_head);
-
-/* Heredoc handling */
-struct s_heredoc_params
-{
-	struct s_ast_command_word	**lines_append;
-	char						*line;
-	char						*delimiter;
-	int							quoted;
-	size_t						delim_len;
-};
 
 t_status	read_heredoc(struct s_ast_redirect *redirect);
 

--- a/src/shenv/get_set.c
+++ b/src/shenv/get_set.c
@@ -6,53 +6,53 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 02:15:43 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/14 18:10:04 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:17:47 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "env.h"
-#include "env_internal.h"
+#include "shenv.h"
+#include "shenv_internal.h"
 
 #include <stdbool.h>
 #include <stdlib.h>
 
 #include "libft.h"
 
-char	*env_get(t_env *env, const char *key)
+char	*shenv_var_get(t_shenv *env, const char *key)
 {
 	size_t	index;
 	size_t	key_len;
 
 	key_len = ft_strlen(key);
-	if (!env_find_index(env, key, key_len, &index))
+	if (!shenv_var_find_index(env, key, key_len, &index))
 		return (NULL);
-	return (env->env_array[index] + key_len + 1);
+	return (env->var_array[index] + key_len + 1);
 }
 
-static t_status	update_existing_entry(t_env *env, int index, char *new_entry)
+static t_status	update_existing_entry(t_shenv *env, int index, char *new_entry)
 {
-	free(env->env_array[index]);
-	env->env_array[index] = new_entry;
+	free(env->var_array[index]);
+	env->var_array[index] = new_entry;
 	return (S_OK);
 }
 
-static t_status	add_new_entry(t_env *env, char *new_entry)
+static t_status	add_new_entry(t_shenv *env, char *new_entry)
 {
 	t_status	status;
 
-	status = env_resize(env);
+	status = shenv_var_array_resize(env);
 	if (status != S_OK)
 	{
 		free(new_entry);
 		return (status);
 	}
-	env->env_array[env->used_size] = new_entry;
-	env->used_size++;
-	env->env_array[env->used_size] = NULL;
+	env->var_array[env->var_array_used] = new_entry;
+	env->var_array_used++;
+	env->var_array[env->var_array_used] = NULL;
 	return (S_OK);
 }
 
-t_status	env_set(t_env *env, const char *key, const char *value)
+t_status	shenv_var_set(t_shenv *env, const char *key, const char *value)
 {
 	size_t	index;
 	char	*new_entry;
@@ -61,26 +61,26 @@ t_status	env_set(t_env *env, const char *key, const char *value)
 
 	key_len = ft_strlen(key);
 	value_len = ft_strlen(value);
-	new_entry = create_env_string(key, key_len, value, value_len);
+	new_entry = shenv_var_create_entry(key, key_len, value, value_len);
 	if (!new_entry)
 		return (status_err(S_EXIT_ERR, ERRMSG_MALLOC, NULL, 0));
-	if (env_find_index(env, key, key_len, &index))
+	if (shenv_var_find_index(env, key, key_len, &index))
 		return (update_existing_entry(env, index, new_entry));
 	return (add_new_entry(env, new_entry));
 }
 
-t_status	env_unset(t_env *env, const char *key)
+t_status	shenv_var_unset(t_shenv *env, const char *key)
 {
 	size_t	index;
 	size_t	key_len;
 
 	key_len = ft_strlen(key);
-	if (!env_find_index(env, key, key_len, &index))
+	if (!shenv_var_find_index(env, key, key_len, &index))
 		return (S_OK);
-	free(env->env_array[index]);
-	ft_memmove(&env->env_array[index], &env->env_array[index + 1],
-		sizeof(char *) * (env->used_size - index));
-	env->used_size--;
-	env->env_array[env->used_size] = NULL;
+	free(env->var_array[index]);
+	ft_memmove(&env->var_array[index], &env->var_array[index + 1],
+		sizeof(char *) * (env->var_array_used - index));
+	env->var_array_used--;
+	env->var_array[env->var_array_used] = NULL;
 	return (S_OK);
 }

--- a/src/shenv/init.c
+++ b/src/shenv/init.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 01:34:15 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 20:17:47 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 21:18:45 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,6 +65,7 @@ t_status	shenv_init(t_shenv *env)
 	t_status	status;
 	size_t		count;
 
+	env->exit_code = 0;
 	count = 0;
 	while (environ && environ[count])
 		count++;

--- a/src/shenv/init.c
+++ b/src/shenv/init.c
@@ -6,12 +6,12 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 01:34:15 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/14 18:15:38 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:17:47 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "env.h"
-#include "env_internal.h"
+#include "shenv.h"
+#include "shenv_internal.h"
 
 #include <stdlib.h>
 
@@ -19,21 +19,21 @@
 
 extern char	**environ;
 
-static t_status	init_env_array(t_env *env, int size)
+static t_status	init_env_array(t_shenv *env, int size)
 {
 	if (size > 0)
-		env->array_size = size * 2;
+		env->var_array_size = size * 2;
 	else
-		env->array_size = 10;
-	env->used_size = 0;
-	env->env_array = malloc(sizeof(char *) * (env->array_size + 1));
-	if (!env->env_array)
+		env->var_array_size = 10;
+	env->var_array_used = 0;
+	env->var_array = malloc(sizeof(char *) * (env->var_array_size + 1));
+	if (!env->var_array)
 		return (status_err(S_RESET_ERR, "malloc", NULL, 0));
-	env->env_array[0] = NULL;
+	env->var_array[0] = NULL;
 	return (S_OK);
 }
 
-static t_status	copy_environ_to_env(t_env *env)
+static t_status	copy_environ_to_env(t_shenv *env)
 {
 	int			i;
 	char		*value;
@@ -47,20 +47,20 @@ static t_status	copy_environ_to_env(t_env *env)
 		value = ft_strdup(environ[i]);
 		if (!value)
 			return (status_err(S_EXIT_ERR, ERRMSG_MALLOC, NULL, 0));
-		status = env_resize(env);
+		status = shenv_var_array_resize(env);
 		if (status != S_OK)
 		{
 			free(value);
 			return (status);
 		}
-		env->env_array[env->used_size++] = value;
-		env->env_array[env->used_size] = NULL;
+		env->var_array[env->var_array_used++] = value;
+		env->var_array[env->var_array_used] = NULL;
 		i++;
 	}
 	return (S_OK);
 }
 
-t_status	env_init(t_env *env)
+t_status	shenv_init(t_shenv *env)
 {
 	t_status	status;
 	size_t		count;
@@ -74,26 +74,26 @@ t_status	env_init(t_env *env)
 	status = copy_environ_to_env(env);
 	if (status != S_OK)
 	{
-		env_free(env);
+		shenv_free(env);
 		return (status);
 	}
 	return (S_OK);
 }
 
-void	env_free(t_env *env)
+void	shenv_free(t_shenv *env)
 {
 	size_t	i;
 
 	if (!env)
 		return ;
-	if (env->env_array)
+	if (env->var_array)
 	{
 		i = 0;
-		while (i < env->used_size)
+		while (i < env->var_array_used)
 		{
-			free(env->env_array[i]);
+			free(env->var_array[i]);
 			i++;
 		}
-		free(env->env_array);
+		free(env->var_array);
 	}
 }

--- a/src/shenv/shenv_internal.h
+++ b/src/shenv/shenv_internal.h
@@ -1,29 +1,29 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   env_internal.h                                     :+:      :+:    :+:   */
+/*   shenv_internal.h                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 03:25:51 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 19:29:03 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:17:47 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef ENV_INTERNAL_H
-# define ENV_INTERNAL_H
+#ifndef SHENV_INTERNAL_H
+# define SHENV_INTERNAL_H
 
-# include "env.h"
+# include "shenv.h"
 
 # include <stddef.h>
 # include <stdbool.h>
 
 # include "status.h"
 
-bool		env_find_index(t_env *env, const char *key,
+bool		shenv_var_find_index(t_shenv *env, const char *key,
 				size_t key_len, size_t *idx_out);
-char		*create_env_string(const char *key, size_t key_len,
+char		*shenv_var_create_entry(const char *key, size_t key_len,
 				const char *value, size_t value_len);
-t_status	env_resize(t_env *env);
+t_status	shenv_var_array_resize(t_shenv *env);
 
 #endif

--- a/src/shenv/utils.c
+++ b/src/shenv/utils.c
@@ -3,32 +3,32 @@
 /*                                                        :::      ::::::::   */
 /*   utils.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 01:54:36 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/27 15:03:06 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:17:47 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "env.h"
-#include "env_internal.h"
+#include "shenv.h"
+#include "shenv_internal.h"
 
 #include <stdbool.h>
 #include <stdlib.h>
 
 #include "libft.h"
 
-bool	env_find_index(t_env *env, const char *key,
+bool	shenv_var_find_index(t_shenv *env, const char *key,
 	size_t key_len, size_t *idx_out)
 {
 	size_t	i;
 
 	i = 0;
-	while (i < env->used_size)
+	while (i < env->var_array_used)
 	{
-		if (ft_strncmp(env->env_array[i], key, key_len) == 0
-			&& (env->env_array[i][key_len] == '='
-			|| env->env_array[i][key_len] == '\0'))
+		if (ft_strncmp(env->var_array[i], key, key_len) == 0
+			&& (env->var_array[i][key_len] == '='
+			|| env->var_array[i][key_len] == '\0'))
 		{
 			*idx_out = i;
 			return (true);
@@ -43,7 +43,7 @@ bool	env_find_index(t_env *env, const char *key,
 	returns a pointer (NULL on allocation failure) instead of t_status. Caller
 	must check the pointer and report allocation error if it is NULL.
 */
-char	*create_env_string(const char *key, size_t key_len,
+char	*shenv_var_create_entry(const char *key, size_t key_len,
 		const char *value, size_t value_len)
 {
 	char	*env_str;
@@ -57,21 +57,21 @@ char	*create_env_string(const char *key, size_t key_len,
 	return (env_str);
 }
 
-t_status	env_resize(t_env *env)
+t_status	shenv_var_array_resize(t_shenv *env)
 {
 	char	**new_array;
 	int		new_size;
 
-	if (env->used_size < env->array_size)
+	if (env->var_array_used < env->var_array_size)
 		return (S_OK);
-	new_size = env->array_size * 2;
+	new_size = env->var_array_size * 2;
 	new_array = malloc(sizeof(char *) * (new_size + 1));
 	if (!new_array)
 		return (status_err(S_EXIT_ERR, ERRMSG_MALLOC, NULL, 0));
-	ft_memcpy(new_array, env->env_array, sizeof(char *) * env->used_size);
-	new_array[env->used_size] = NULL;
-	free(env->env_array);
-	env->env_array = new_array;
-	env->array_size = new_size;
+	ft_memcpy(new_array, env->var_array, sizeof(char *) * env->var_array_used);
+	new_array[env->var_array_used] = NULL;
+	free(env->var_array);
+	env->var_array = new_array;
+	env->var_array_size = new_size;
 	return (S_OK);
 }

--- a/src/status.c
+++ b/src/status.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   status.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/26 20:11:15 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/03 14:58:09 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:45:24 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "shenv.h"
 #include "libft.h"
 #include "shenv.h"
 #include "util.h"
@@ -77,19 +78,19 @@ void	status_warn(const char *msg, const char *extra, int errnum)
 	util_write_all(STDERR_FILENO, buf, len);
 }
 
-void	status_set_exit_code(t_status status, int *exit_code)
+void	status_set_exit_code(t_status status, t_shenv *env)
 {
 	if (status == S_EXIT_ERR || status == S_RESET_ERR || status == S_COMM_ERR
 		|| status == S_BUILTIN_ERR)
-		*exit_code = 1;
+		env->exit_code = 1;
 	else if (status == S_RESET_SYNTAX || status == S_BUILTIN_ARG)
-		*exit_code = 2;
+		env->exit_code = 2;
 	else if (status == S_RESET_SIGINT)
-		*exit_code = 128 + SIGINT;
+		env->exit_code = 128 + SIGINT;
 }
 
-t_status	status_force_exit(t_status status, int *exit_code)
+t_status	status_force_exit(t_status status, t_shenv *env)
 {
-	status_set_exit_code(status, exit_code);
+	status_set_exit_code(status, env);
 	return (S_EXIT_OK);
 }

--- a/src/status.c
+++ b/src/status.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 
 #include "libft.h"
+#include "shenv.h"
 #include "util.h"
 
 t_status	status_err(t_status status,

--- a/src/test/env.c
+++ b/src/test/env.c
@@ -3,40 +3,41 @@
 /*                                                        :::      ::::::::   */
 /*   env.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/10 12:20:42 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 19:00:09 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
-#include "env.h"
+
+#include "shenv.h"
 #include "status.h"
 
-static void	print_env_variable(t_env *env, const char *var_name)
+static void	print_env_variable(t_shenv *env, const char *var_name)
 {
 	char	*value;
 
-	value = env_get(env, var_name);
+	value = shenv_var_get(env, var_name);
 	if (value)
 		printf("%s=%s\n", var_name, value);
 	else
 		printf("%s=(null)\n", var_name);
 }
 
-static void	test_env_get(t_env *env)
+static void	test_env_get(t_shenv *env)
 {
-	printf("\n1. Testing env_get for HOME:\n");
+	printf("\n1. Testing shenv_var_get for HOME:\n");
 	print_env_variable(env, "HOME");
 }
 
-static void	test_env_set_new(t_env *env)
+static void	test_env_set_new(t_shenv *env)
 {
 	t_status	result;
 
-	printf("\n2. Testing env_set for new variable TEST_VAR:\n");
-	result = env_set(env, "TEST_VAR", "Hello World");
+	printf("\n2. Testing shenv_var_set for new variable TEST_VAR:\n");
+	result = shenv_var_set(env, "TEST_VAR", "Hello World");
 	if (result == S_OK)
 		printf("Successfully set TEST_VAR\n");
 	else
@@ -44,14 +45,14 @@ static void	test_env_set_new(t_env *env)
 	print_env_variable(env, "TEST_VAR");
 }
 
-static void	test_env_set_existing(t_env *env)
+static void	test_env_set_existing(t_shenv *env)
 {
 	t_status	result;
 
-	printf("\n3. Testing env_set to modify existing variable HOME:\n");
+	printf("\n3. Testing shenv_var_set to modify existing variable HOME:\n");
 	printf("Before: ");
 	print_env_variable(env, "HOME");
-	result = env_set(env, "HOME", "/temp/home");
+	result = shenv_var_set(env, "HOME", "/temp/home");
 	if (result == S_OK)
 		printf("Successfully modified HOME\n");
 	else
@@ -60,14 +61,14 @@ static void	test_env_set_existing(t_env *env)
 	print_env_variable(env, "HOME");
 }
 
-static void	test_env_unset(t_env *env)
+static void	test_env_unset(t_shenv *env)
 {
 	t_status	result;
 
-	printf("\n4. Testing env_unset for TEST_VAR:\n");
+	printf("\n4. Testing shenv_var_unset for TEST_VAR:\n");
 	printf("Before: ");
 	print_env_variable(env, "TEST_VAR");
-	result = env_unset(env, "TEST_VAR");
+	result = shenv_var_unset(env, "TEST_VAR");
 	if (result == S_OK)
 		printf("Successfully unset TEST_VAR\n");
 	else
@@ -88,24 +89,24 @@ static void	print_array_items(char **array, int count)
 	}
 }
 
-static void	test_env_array(t_env *env)
+static void	test_env_array(t_shenv *env)
 {
-	char	**env_array;
+	char	**var_array;
 
 	printf("\n5. Testing env array (showing first 10 items):\n");
-	env_array = env->env_array;
-	print_array_items(env_array, 10);
+	var_array = env->var_array;
+	print_array_items(var_array, 10);
 	printf("... (and more)\n");
 }
 
 int	main(void)
 {
-	t_env		env;
+	t_shenv		env;
 	t_status	status;
 
 	printf("--- Testing Environment Functions ---\n\n");
 	printf("Initializing environment...\n");
-	status = env_init(&env);
+	status = shenv_init(&env);
 	if (status != S_OK)
 	{
 		printf("Failed to initialize environment\n");
@@ -117,7 +118,7 @@ int	main(void)
 	test_env_unset(&env);
 	test_env_array(&env);
 	printf("\nCleaning up environment...\n");
-	env_free(&env);
+	shenv_free(&env);
 	printf("Test completed.\n");
 	return (0);
 }

--- a/src/test/heredoc.c
+++ b/src/test/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 10:32:56 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 20:22:02 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 22:22:31 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,8 +31,10 @@
 #define CYAN "\033[0;36m"
 #define RESET "\033[0m"
 
-/* Function declarations */
+/* Declare internal functions from parser and execute modules */
+
 t_status	read_heredoc(struct s_ast_redirect *redirect);
+int			process_heredoc(struct s_ast_redirect *redirect);
 
 /* Print test result */
 static void	print_result(const char *name, bool passed)

--- a/src/test/list.c
+++ b/src/test/list.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 23:14:19 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/21 04:13:10 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,8 @@
 #include <unistd.h>
 
 #include "ast.h"
-#include "env.h"
 #include "execute.h"
+#include "shenv.h"
 #include "status.h"
 
 /*
@@ -67,11 +67,11 @@ struct s_ast_list_entry	*g_test_list
 
 int	main(void)
 {
-	t_env		env;
+	t_shenv		env;
 	t_status	status;
 	int			exit_code;
 
-	status = env_init(&env);
+	status = shenv_init(&env);
 	if (status != S_OK)
 		return (1);
 	exit_code = -1;
@@ -79,5 +79,5 @@ int	main(void)
 	dprintf(STDERR_FILENO,
 		"execute_list returned internal status %d, exit code %d\n",
 		status, exit_code);
-	env_free(&env);
+	shenv_free(&env);
 }

--- a/src/test/list.c
+++ b/src/test/list.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/05 23:14:19 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:46:57 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,15 +69,14 @@ int	main(void)
 {
 	t_shenv		env;
 	t_status	status;
-	int			exit_code;
 
 	status = shenv_init(&env);
 	if (status != S_OK)
 		return (1);
-	exit_code = -1;
-	status = execute_list(g_test_list, &env, &exit_code);
+	env.exit_code = -1;
+	status = execute_list(g_test_list, &env);
 	dprintf(STDERR_FILENO,
 		"execute_list returned internal status %d, exit code %d\n",
-		status, exit_code);
+		status, env.exit_code);
 	shenv_free(&env);
 }

--- a/src/test/path_execve.c
+++ b/src/test/path_execve.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   path_execve.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 15:30:33 by josmanov          #+#    #+#             */
-/*   Updated: 2025/05/12 19:15:57 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,9 +18,10 @@
 #include <sys/wait.h>
 #include <sys/stat.h>
 #include <errno.h>
-#include "env.h"
 
-void	handle_path_search(char **argv, t_env *env, int *exit_code);
+#include "shenv.h"
+
+void	handle_path_search(char **argv, t_shenv *env, int *exit_code);
 
 #define RESET   "\033[0m"
 #define RED     "\033[31m"
@@ -36,7 +37,7 @@ static void	print_result(const char *name, bool passed)
 		printf("[%sFAIL%s] %s%s%s\n", RED, RESET, CYAN, name, RESET);
 }
 
-static int	test_in_child(char **argv, t_env *env)
+static int	test_in_child(char **argv, t_shenv *env)
 {
 	pid_t	child_pid;
 	int		status;
@@ -64,15 +65,15 @@ static int	test_in_child(char **argv, t_env *env)
 
 static void	test_not_found(void)
 {
-	t_env	env;
+	t_shenv	env;
 	char	*path_list;
 	char	*argv[2];
 	int		exit_code;
 
 	printf("\n%sTesting command not found%s\n", YELLOW, RESET);
 	path_list = strdup("/bin:/usr/bin:/usr/local/bin");
-	env_init(&env);
-	env_set(&env, "PATH", path_list);
+	shenv_init(&env);
+	shenv_var_set(&env, "PATH", path_list);
 	argv[0] = "nonexistentcommand123456789";
 	argv[1] = NULL;
 	printf("  Command: %s\n", argv[0]);
@@ -80,21 +81,21 @@ static void	test_not_found(void)
 	exit_code = test_in_child(argv, &env);
 	printf("  Exit code: %d\n", exit_code);
 	print_result("command_not_found_returns_127", exit_code == 127);
-	env_free(&env);
+	shenv_free(&env);
 	free(path_list);
 }
 
 static void	test_found(void)
 {
-	t_env	env;
+	t_shenv	env;
 	char	*path_list;
 	char	*argv[3];
 	int		exit_code;
 
 	printf("\n%sTesting command found%s\n", YELLOW, RESET);
 	path_list = strdup("/bin:/usr/bin:/usr/local/bin");
-	env_init(&env);
-	env_set(&env, "PATH", path_list);
+	shenv_init(&env);
+	shenv_var_set(&env, "PATH", path_list);
 	argv[0] = "echo";
 	argv[1] = "test";
 	argv[2] = NULL;
@@ -103,21 +104,21 @@ static void	test_found(void)
 	exit_code = test_in_child(argv, &env);
 	printf("  Exit code: %d\n", exit_code);
 	print_result("command_found_executes", exit_code == 0);
-	env_free(&env);
+	shenv_free(&env);
 	free(path_list);
 }
 
 static void	test_absolute(void)
 {
-	t_env	env;
+	t_shenv	env;
 	char	*path_list;
 	char	*argv[3];
 	int		exit_code;
 
 	printf("\n%sTesting absolute path%s\n", YELLOW, RESET);
 	path_list = strdup("/bin:/usr/bin:/usr/local/bin");
-	env_init(&env);
-	env_set(&env, "PATH", path_list);
+	shenv_init(&env);
+	shenv_var_set(&env, "PATH", path_list);
 	argv[0] = "/bin/echo";
 	argv[1] = "test";
 	argv[2] = NULL;
@@ -126,7 +127,7 @@ static void	test_absolute(void)
 	exit_code = test_in_child(argv, &env);
 	printf("  Exit code: %d\n", exit_code);
 	print_result("absolute_path_executes", exit_code == 0);
-	env_free(&env);
+	shenv_free(&env);
 	free(path_list);
 }
 

--- a/src/test/path_execve.c
+++ b/src/test/path_execve.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 15:30:33 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:50:36 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,7 @@
 
 #include "shenv.h"
 
-void	handle_path_search(char **argv, t_shenv *env, int *exit_code);
+void	handle_path_search(char **argv, t_shenv *env);
 
 #define RESET   "\033[0m"
 #define RED     "\033[31m"
@@ -37,30 +37,26 @@ static void	print_result(const char *name, bool passed)
 		printf("[%sFAIL%s] %s%s%s\n", RED, RESET, CYAN, name, RESET);
 }
 
-static int	test_in_child(char **argv, t_shenv *env)
+static void	test_in_child(char **argv, t_shenv *env)
 {
 	pid_t	child_pid;
 	int		status;
-	int		exit_code;
 
+	env->exit_code = -1;
 	child_pid = fork();
 	if (child_pid == -1)
 	{
 		perror("fork");
-		return (-1);
+		return ;
 	}
 	if (child_pid == 0)
 	{
-		handle_path_search(argv, env, &exit_code);
-		exit(exit_code);
+		handle_path_search(argv, env);
+		exit(env->exit_code);
 	}
 	waitpid(child_pid, &status, 0);
 	if (WIFEXITED(status))
-	{
-		exit_code = WEXITSTATUS(status);
-		return (exit_code);
-	}
-	return (-1);
+		env->exit_code = WEXITSTATUS(status);
 }
 
 static void	test_not_found(void)
@@ -68,7 +64,6 @@ static void	test_not_found(void)
 	t_shenv	env;
 	char	*path_list;
 	char	*argv[2];
-	int		exit_code;
 
 	printf("\n%sTesting command not found%s\n", YELLOW, RESET);
 	path_list = strdup("/bin:/usr/bin:/usr/local/bin");
@@ -78,9 +73,9 @@ static void	test_not_found(void)
 	argv[1] = NULL;
 	printf("  Command: %s\n", argv[0]);
 	printf("  PATH: %s\n", path_list);
-	exit_code = test_in_child(argv, &env);
-	printf("  Exit code: %d\n", exit_code);
-	print_result("command_not_found_returns_127", exit_code == 127);
+	test_in_child(argv, &env);
+	printf("  Exit code: %d\n", env.exit_code);
+	print_result("command_not_found_returns_127", env.exit_code == 127);
 	shenv_free(&env);
 	free(path_list);
 }
@@ -90,7 +85,6 @@ static void	test_found(void)
 	t_shenv	env;
 	char	*path_list;
 	char	*argv[3];
-	int		exit_code;
 
 	printf("\n%sTesting command found%s\n", YELLOW, RESET);
 	path_list = strdup("/bin:/usr/bin:/usr/local/bin");
@@ -101,9 +95,9 @@ static void	test_found(void)
 	argv[2] = NULL;
 	printf("  Command: %s %s\n", argv[0], argv[1]);
 	printf("  PATH: %s\n", path_list);
-	exit_code = test_in_child(argv, &env);
-	printf("  Exit code: %d\n", exit_code);
-	print_result("command_found_executes", exit_code == 0);
+	test_in_child(argv, &env);
+	printf("  Exit code: %d\n", env.exit_code);
+	print_result("command_found_executes", env.exit_code == 0);
 	shenv_free(&env);
 	free(path_list);
 }
@@ -113,7 +107,6 @@ static void	test_absolute(void)
 	t_shenv	env;
 	char	*path_list;
 	char	*argv[3];
-	int		exit_code;
 
 	printf("\n%sTesting absolute path%s\n", YELLOW, RESET);
 	path_list = strdup("/bin:/usr/bin:/usr/local/bin");
@@ -124,9 +117,9 @@ static void	test_absolute(void)
 	argv[2] = NULL;
 	printf("  Command: %s %s\n", argv[0], argv[1]);
 	printf("  PATH: %s\n", path_list);
-	exit_code = test_in_child(argv, &env);
-	printf("  Exit code: %d\n", exit_code);
-	print_result("absolute_path_executes", exit_code == 0);
+	test_in_child(argv, &env);
+	printf("  Exit code: %d\n", env.exit_code);
+	print_result("absolute_path_executes", env.exit_code == 0);
 	shenv_free(&env);
 	free(path_list);
 }

--- a/src/test/pipeline.c
+++ b/src/test/pipeline.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 18:35:02 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 20:47:37 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 22:20:49 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,12 @@
 #include "execute.h"
 #include "shenv.h"
 #include "status.h"
+
+/*
+	We're testing internal function of execute module - just forward declare it.
+*/
+t_status	execute_pipeline(struct s_ast_simple_command *pipeline_head,
+				t_shenv *env);
 
 /*
 	/bin/echo -e first\n\n\ntest > test_pipeline_tmpout |

--- a/src/test/pipeline.c
+++ b/src/test/pipeline.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 18:35:02 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/21 04:13:20 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,8 @@
 #include <unistd.h>
 
 #include "ast.h"
-#include "env.h"
 #include "execute.h"
+#include "shenv.h"
 #include "status.h"
 
 /*
@@ -87,11 +87,11 @@ struct s_ast_simple_command	*g_test_pipeline
 
 int	main(void)
 {
-	t_env		env;
+	t_shenv		env;
 	t_status	status;
 	int			exit_code;
 
-	status = env_init(&env);
+	status = shenv_init(&env);
 	if (status != S_OK)
 		return (1);
 	exit_code = -1;
@@ -99,6 +99,6 @@ int	main(void)
 	dprintf(STDERR_FILENO,
 		"execute_pipeline returned internal status %d, exit code %d\n",
 		status, exit_code);
-	env_free(&env);
+	shenv_free(&env);
 	return (exit_code);
 }

--- a/src/test/pipeline.c
+++ b/src/test/pipeline.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 18:35:02 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:47:37 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -89,16 +89,15 @@ int	main(void)
 {
 	t_shenv		env;
 	t_status	status;
-	int			exit_code;
 
 	status = shenv_init(&env);
 	if (status != S_OK)
 		return (1);
-	exit_code = -1;
-	status = execute_pipeline(g_test_pipeline, &env, &exit_code);
+	env.exit_code = -1;
+	status = execute_pipeline(g_test_pipeline, &env);
 	dprintf(STDERR_FILENO,
 		"execute_pipeline returned internal status %d, exit code %d\n",
-		status, exit_code);
+		status, env.exit_code);
 	shenv_free(&env);
-	return (exit_code);
+	return (env.exit_code);
 }

--- a/src/test/simple_command.c
+++ b/src/test/simple_command.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 18:11:56 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/29 19:32:36 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,8 +15,8 @@
 #include <unistd.h>
 
 #include "ast.h"
-#include "env.h"
 #include "execute.h"
+#include "shenv.h"
 #include "status.h"
 
 /*
@@ -45,11 +45,11 @@ struct s_ast_simple_command	*g_test_command
 
 int	main(void)
 {
-	t_env		env;
+	t_shenv		env;
 	t_status	status;
 	int			exit_code;
 
-	status = env_init(&env);
+	status = shenv_init(&env);
 	if (status != S_OK)
 		return (1);
 	exit_code = -1;
@@ -57,6 +57,6 @@ int	main(void)
 	dprintf(STDERR_FILENO,
 		"execute_simple_command returned internal status %d, exit code %d\n",
 		status, exit_code);
-	env_free(&env);
+	shenv_free(&env);
 	return (exit_code);
 }

--- a/src/test/simple_command.c
+++ b/src/test/simple_command.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 18:11:56 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 20:14:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 20:47:58 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,16 +47,15 @@ int	main(void)
 {
 	t_shenv		env;
 	t_status	status;
-	int			exit_code;
 
 	status = shenv_init(&env);
 	if (status != S_OK)
 		return (1);
-	exit_code = -1;
-	status = execute_simple_command(g_test_command, &env, &exit_code, false);
+	env.exit_code = -1;
+	status = execute_simple_command(g_test_command, &env, false);
 	dprintf(STDERR_FILENO,
 		"execute_simple_command returned internal status %d, exit code %d\n",
-		status, exit_code);
+		status, env.exit_code);
 	shenv_free(&env);
-	return (exit_code);
+	return (env.exit_code);
 }

--- a/src/test/simple_command.c
+++ b/src/test/simple_command.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 18:11:56 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 20:47:58 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 22:20:36 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,12 @@
 #include "execute.h"
 #include "shenv.h"
 #include "status.h"
+
+/*
+	We're testing internal function of execute module - just forward declare it.
+*/
+t_status	execute_simple_command(struct s_ast_simple_command *command,
+				t_shenv *env, bool is_child);
 
 /*
 	/bin/echo hello world! > test_simple_trunc_nooutput >> test_simple_app

--- a/src/test/wordexp.c
+++ b/src/test/wordexp.c
@@ -6,30 +6,32 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/04 17:56:49 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/26 18:42:19 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 23:29:00 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "shenv.h"
 #include "status.h"
 #include "word.h"
 
 int	main(int argc, char **argv)
 {
-	int					i;
 	struct s_word_field	*fields;
 	struct s_word_field	**fields_append;
 	struct s_word_field	*next;
 	t_status			status;
+	t_shenv				env;
 
-	i = 1;
-	while (i < argc)
+	shenv_init(&env);
+	(void)argc;
+	while (*++argv)
 	{
-		printf("\e[31mWord  : \e[91m%s\e[0m\n", argv[i]);
+		printf("\e[31mWord  : \e[91m%s\e[0m\n", *argv);
 		fields_append = &fields;
-		status = word_expand(argv[i], &fields_append);
+		status = word_expand(*argv, &fields_append, &env);
 		while (fields)
 		{
 			if (status == S_OK)
@@ -40,6 +42,5 @@ int	main(int argc, char **argv)
 		}
 		if (status != S_OK)
 			return (1);
-		i++;
 	}
 }

--- a/src/test/wordhere.c
+++ b/src/test/wordhere.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 15:51:26 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/12 21:56:10 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 23:30:19 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <readline/readline.h>
 
+#include "shenv.h"
 #include "status.h"
 #include "word.h"
 
@@ -31,7 +32,7 @@ static void	error_exit(char *msg)
 	exit(1);
 }
 
-static void	heredoc_loop(char *delimiter, bool quoted)
+static void	heredoc_loop(char *delimiter, bool quoted, t_shenv *env)
 {
 	char	*line;
 
@@ -48,7 +49,7 @@ static void	heredoc_loop(char *delimiter, bool quoted)
 		}
 		if (quoted)
 			printf(GREEN "Received line >" BRED "%s" GREEN "<" RESETNL, line);
-		else if (word_heredoc_line(&line) == S_OK)
+		else if (word_heredoc_line(&line, env) == S_OK)
 			printf(GREEN "Expanded line >" BRED "%s" GREEN "<" RESETNL, line);
 		else
 		{
@@ -63,13 +64,15 @@ int	main(void)
 {
 	char	*delimiter;
 	bool	quoted;
+	t_shenv	env;
 
+	shenv_init(&env);
 	delimiter = readline(RLYELLOW "Heredoc delimiter: " RLRESET);
 	if (!delimiter)
 		error_exit("Readline returned null");
 	quoted = word_heredoc_delimiter(delimiter);
 	printf(GREEN "Looking for delimiter >" BRED "%s" GREEN "<" RESETNL,
 		delimiter);
-	heredoc_loop(delimiter, quoted);
+	heredoc_loop(delimiter, quoted, &env);
 	free(delimiter);
 }

--- a/src/word/word.c
+++ b/src/word/word.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/28 16:54:57 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/26 19:28:54 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 21:37:41 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#include "shenv.h"
 #include "status.h"
 
 void	word_free(struct s_word_field *fields)
@@ -38,13 +39,15 @@ void	word_free(struct s_word_field *fields)
 	by the caller, but their content is undefined. The append pointer itself is
 	updated past the new fields only on success.
 */
-t_status	word_expand(char *word, struct s_word_field ***fields_append)
+t_status	word_expand(char *word, struct s_word_field ***fields_append,
+	t_shenv *env)
 {
 	struct s_word_state	state;
 	struct s_word_field	**fields_out;
 	t_status			status;
 
 	fields_out = *fields_append;
+	state.env = env;
 	state.word = word;
 	state.out = NULL;
 	state.out_append = fields_out;

--- a/src/word/word_exp.c
+++ b/src/word/word_exp.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 14:12:48 by amakinen          #+#    #+#             */
-/*   Updated: 2025/04/16 15:15:01 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 21:36:58 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 
 #include <stdlib.h>
 
+#include "shenv.h"
 #include "util.h"
 
 /*
@@ -22,7 +23,7 @@
 
 	TODO: implement correct value for `$?`.
 */
-char	*word_exp_parse(char **word)
+char	*word_exp_parse(char **word, t_shenv *env)
 {
 	char	*name_start;
 	char	*value;
@@ -40,7 +41,7 @@ char	*word_exp_parse(char **word)
 			(*word)++;
 		name_end_tmp = **word;
 		**word = '\0';
-		value = getenv(name_start);
+		value = shenv_var_get(env, name_start);
 		**word = name_end_tmp;
 		if (!value)
 			value = "";

--- a/src/word/word_exp.c
+++ b/src/word/word_exp.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 14:12:48 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/04 21:36:58 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 23:50:35 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,36 +17,48 @@
 #include "shenv.h"
 #include "util.h"
 
+static char	*word_exp_parse_varname(char **word, t_shenv *env)
+{
+	char		*name_start;
+	char		*value;
+	char		name_end_tmp;
+
+	name_start = *word;
+	while (util_isname(**word))
+		(*word)++;
+	name_end_tmp = **word;
+	**word = '\0';
+	value = shenv_var_get(env, name_start);
+	**word = name_end_tmp;
+	if (!value)
+		value = "";
+	return (value);
+}
+
+/*
+	Exit code is converted in a static array. Callers should immediately read
+	the string and copy the characters to their output. 12 characters is enough
+	for 32-bit INT_MIN (including the minus sign) and the null terminator.
+*/
+static char	*word_exp_parse_exitcode(char **word, t_shenv *env)
+{
+	static char	exit_code_str[12];
+
+	(*word)++;
+	util_itoa_base(env->exit_code, "0123456789", exit_code_str);
+	return (exit_code_str);
+}
+
 /*
 	Identify and consume the expansion following a `$`, and return a pointer
 	to its value. If no valid expansion is found, a null pointer is returned.
-
-	TODO: implement correct value for `$?`.
 */
 char	*word_exp_parse(char **word, t_shenv *env)
 {
-	char	*name_start;
-	char	*value;
-	char	name_end_tmp;
-
 	if (**word == '?')
-	{
-		(*word)++;
-		value = "0";
-	}
+		return (word_exp_parse_exitcode(word, env));
 	else if (util_isname(**word))
-	{
-		name_start = *word;
-		while (util_isname(**word))
-			(*word)++;
-		name_end_tmp = **word;
-		**word = '\0';
-		value = shenv_var_get(env, name_start);
-		**word = name_end_tmp;
-		if (!value)
-			value = "";
-	}
+		return (word_exp_parse_varname(word, env));
 	else
 		return (NULL);
-	return (value);
 }

--- a/src/word/word_internal.h
+++ b/src/word/word_internal.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/09 16:24:21 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/09 18:17:44 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 21:37:19 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@
 # include <stdbool.h>
 # include <stddef.h>
 
+# include "shenv.h"
 # include "status.h"
 
 # define INTERNAL_ESCAPE '\001'
@@ -24,6 +25,7 @@ struct	s_word_field;
 
 struct	s_word_state
 {
+	t_shenv				*env;
 	char				*word;
 	struct s_word_field	*out;
 	struct s_word_field	**out_append;
@@ -41,7 +43,7 @@ struct	s_word_pattern
 	size_t	prefix_len;
 };
 
-char		*word_exp_parse(char **word);
+char		*word_exp_parse(char **word, t_shenv *env);
 
 t_status	word_filename(char *pattern, struct s_word_field ***matches_append,
 				bool *had_matches);

--- a/src/word/word_scan.c
+++ b/src/word/word_scan.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/11 15:18:16 by amakinen          #+#    #+#             */
-/*   Updated: 2025/05/09 18:31:22 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/04 21:35:10 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,7 +60,7 @@ t_status	word_scan_expansion(struct s_word_state *state, bool quoted)
 	char		c;
 	t_status	status;
 
-	value = word_exp_parse(&state->word);
+	value = word_exp_parse(&state->word, state->env);
 	if (!value)
 	{
 		word_out_char(state, '$', quoted);


### PR DESCRIPTION
Use custom env getter instead of getenv for expansions, and implement exit_code expansion.

Move heredoc expansion from parsing to execution.

Rename env module to shenv and move exit_code inside t_shenv.