### PR TITLE
Refactor external command execution to use t_status

### DIFF
--- a/include/status.h
+++ b/include/status.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/24 21:50:28 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/12 18:57:27 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/12 21:51:05 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,6 +47,8 @@ typedef enum e_status
 	S_RESET_SYNTAX,
 	S_RESET_SIGINT,
 	S_COMM_ERR,
+	S_EXEC_ERR,
+	S_EXEC_NOTFOUND,
 	S_BUILTIN_ERR,
 	S_BUILTIN_ARG,
 }	t_status;

--- a/src/execute/execute_internal.h
+++ b/src/execute/execute_internal.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:27:27 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/12 18:49:02 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/12 22:46:09 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,14 +18,6 @@
 # include "ast.h"
 # include "shenv.h"
 # include "status.h"
-
-/*
-	Internal functions for command execution
-	These functions handle the finding and executing external commands
-*/
-void		handle_absolute_path(char **argv, t_shenv *env);
-
-void		handle_path_search(char **argv, t_shenv *env);
 
 struct	s_pipeline_fds
 {
@@ -56,5 +48,14 @@ t_status	execute_redirect_heredoc(struct s_ast_redirect *redirect,
 t_status	execute_redirect_prepare(struct s_redir_fds *fds,
 				struct s_ast_redirect *redirs, t_shenv *env);
 t_status	execute_redirect_finish(struct s_redir_fds *fds, bool apply);
+
+struct	s_path_search
+{
+	char	*cand_dir;
+	bool	found;
+	int		found_errno;
+};
+
+t_status	execute_external_command(char **argv, t_shenv *env);
 
 #endif

--- a/src/execute/simple_command.c
+++ b/src/execute/simple_command.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 17:21:06 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/12 18:49:39 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/12 23:25:27 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -148,7 +148,7 @@ static t_status	execute_command_execute(struct s_ast_redirect *redirs,
 	if (is_external)
 		status = execute_redirect_finish(&fds, true);
 	if (is_external && status == S_OK)
-		handle_path_search(argv, env);
+		status = execute_external_command(argv, env);
 	if (builtin && fds.out == NO_REDIR)
 		status = builtin(argv, env, STDOUT_FILENO);
 	else if (builtin)

--- a/src/status.c
+++ b/src/status.c
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/26 20:11:15 by amakinen          #+#    #+#             */
-/*   Updated: 2025/06/12 19:25:50 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/12 22:55:13 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "shenv.h"
 #include "libft.h"
 #include "shenv.h"
 #include "util.h"
@@ -85,6 +84,10 @@ void	status_set_exit_code(t_status status, t_shenv *env)
 		env->exit_code = 1;
 	else if (status == S_RESET_SYNTAX || status == S_BUILTIN_ARG)
 		env->exit_code = 2;
+	else if (status == S_EXEC_ERR)
+		env->exit_code = 126;
+	else if (status == S_EXEC_NOTFOUND)
+		env->exit_code = 127;
 	else if (status == S_RESET_SIGINT)
 		env->exit_code = 128 + SIGINT;
 }

--- a/src/test/path_execve.c
+++ b/src/test/path_execve.c
@@ -6,22 +6,22 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 15:30:33 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 20:50:36 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/12 23:38:48 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
-#include <unistd.h>
+#include <sys/types.h>
 #include <sys/wait.h>
-#include <sys/stat.h>
-#include <errno.h>
+#include <unistd.h>
 
 #include "shenv.h"
+#include "status.h"
 
-void	handle_path_search(char **argv, t_shenv *env);
+t_status	execute_external_command(char **argv, t_shenv *env);
 
 #define RESET   "\033[0m"
 #define RED     "\033[31m"
@@ -51,7 +51,8 @@ static void	test_in_child(char **argv, t_shenv *env)
 	}
 	if (child_pid == 0)
 	{
-		handle_path_search(argv, env);
+		status = execute_external_command(argv, env);
+		status_set_exit_code(status, env);
 		exit(env->exit_code);
 	}
 	waitpid(child_pid, &status, 0);


### PR DESCRIPTION
Malloc errors now report exit code 1 instead (via S_EXIT_ERR).

Also fix exit code for execve errors: default to 126 (via S_EXEC_ERR) for non-ENOENT instead of 127 for non-EACCES.