### PR TITLE
Reorganize var_set helpers a bit

### DIFF
--- a/src/shenv/shenv_init.c
+++ b/src/shenv/shenv_init.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   shenv_init.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 01:34:15 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/13 00:21:15 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/13 16:45:45 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,7 +57,7 @@ static t_status	shenv_var_init(t_shenv *env, int size)
 	env->var_array_used = 0;
 	env->var_array = malloc(sizeof(char *) * (env->var_array_size + 1));
 	if (!env->var_array)
-		return (status_err(S_RESET_ERR, "malloc", NULL, 0));
+		return (status_err(S_RESET_ERR, ERRMSG_MALLOC, NULL, 0));
 	env->var_array[0] = NULL;
 	return (shenv_var_copy_environ(env));
 }

--- a/src/shenv/shenv_internal.h
+++ b/src/shenv/shenv_internal.h
@@ -6,7 +6,7 @@
 /*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 03:25:51 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/04 20:17:47 by amakinen         ###   ########.fr       */
+/*   Updated: 2025/06/13 16:57:15 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,8 +22,6 @@
 
 bool		shenv_var_find_index(t_shenv *env, const char *key,
 				size_t key_len, size_t *idx_out);
-char		*shenv_var_create_entry(const char *key, size_t key_len,
-				const char *value, size_t value_len);
 t_status	shenv_var_array_resize(t_shenv *env);
 
 #endif

--- a/src/shenv/shenv_var_utils.c
+++ b/src/shenv/shenv_var_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   shenv_var_utils.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: josmanov <josmanov@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: amakinen <amakinen@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/08 01:54:36 by josmanov          #+#    #+#             */
-/*   Updated: 2025/06/13 00:21:25 by josmanov         ###   ########.fr       */
+/*   Updated: 2025/06/13 16:57:38 by amakinen         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,25 +36,6 @@ bool	shenv_var_find_index(t_shenv *env, const char *key,
 		i++;
 	}
 	return (false);
-}
-
-/*
-	Allocate a string for an environment value. Due to limit of four arguments,
-	returns a pointer (NULL on allocation failure) instead of t_status. Caller
-	must check the pointer and report allocation error if it is NULL.
-*/
-char	*shenv_var_create_entry(const char *key, size_t key_len,
-		const char *value, size_t value_len)
-{
-	char	*env_str;
-
-	env_str = malloc(key_len + value_len + 2);
-	if (!env_str)
-		return (NULL);
-	ft_strlcpy(env_str, key, key_len + 1);
-	env_str[key_len] = '=';
-	ft_strlcpy(env_str + key_len + 1, value, value_len + 1);
-	return (env_str);
 }
 
 t_status	shenv_var_array_resize(t_shenv *env)


### PR DESCRIPTION
Merge _update_existing and _add_new into single _store_entry. This allows moving _create_entry into the same file as file-local, making it easier to verify the malloc error checking as it doesn't use the typical style.

Also fix malloc error message in shenv_var_init.